### PR TITLE
broken link to applicant information

### DIFF
--- a/_pages/hackweeks.md
+++ b/_pages/hackweeks.md
@@ -18,4 +18,4 @@ the success of the previous *Astro-*, *Neuro-*, and *Geohackweeks*. This is an e
 with the nature of oceanographic research where data are large and complex and the
 community is diverse and collaborative.
 
-[See what we will do in the Oceanhackweek](https://oceanhackweek.github.io/2018/04/02/information-for-applicants.html)
+[See what we will do in the Oceanhackweek](https://oceanhackweek.github.io/applicant-info.html)


### PR DESCRIPTION
Got rid a 404 error given by a broken link on line 21. When "See what we will do in the Oceanhackweek" is clicked, it leads to a nonexistent page. I inferred that `information-for-applicants.html` was likely an old version of `applicant-info.html`.