### PR TITLE
changed repo links to use ohw links

### DIFF
--- a/_pages/curriculum.md
+++ b/_pages/curriculum.md
@@ -159,7 +159,7 @@ permalink: curriculum.html
   <tbody>
     <tr>
       <td>9:00AM - 10:30AM</td>
-      <td><strong><a href="https://github.com/pangeo-data/pangeo-tutorial/blob/master/notebooks/xarray.ipynb">Handle</a> "Big" <a href="https://github.com/pangeo-data/pangeo-tutorial/blob/master/notebooks/dask.ipynb">Larger-than-memory</a> <a href="https://github.com/pangeo-data/pangeo-ocean-examples/blob/master/ecco_v4_example.ipynb">Data</a></strong></td>
+      <td><strong><a href="https://github.com/oceanhackweek/ohw19-tutorial-handle-big-data/blob/master/notebooks/xarray.ipynb">Handle</a> "Big" <a href="https://github.com/oceanhackweek/ohw19-tutorial-handle-big-data/blob/master/notebooks/dask.ipynb">Larger-than-memory</a> <a href="https://github.com/oceanhackweek/ohw19-tutorial-handle-big-data/blob/master/notebooks/ecco_v4_example.ipynb">Data</a></strong></td>
       <td>Joe Hamman, Ryan Abernathey</td>
     </tr>
  <tr>


### PR DESCRIPTION
The links for Wednesday's  "Handle "Big" Larger-than-memory Data" tutorial points to a Pangeo repository that is subject to change. 

In order to preserve the notebooks used during OceanHackWeek 2019, copies of the notebooks were made in an ohw repo which the links for the tutorial now links to.


