### PR TITLE
check gh-page build status

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,17 @@
+name: GH-Pages Status
+on:
+  page_build
+  
+jobs:
+  see-page-build-payload:
+    runs-on: ubuntu-latest
+    steps:      
+      - name: check status
+        run: |
+          import os
+          status, errormsg = os.getenv('STATUS'), os.getenv('ERROR')
+          assert status == 'built', 'There was an error building the page on GitHub pages.\n\nStatus: {}\n\nError messsage: {}'.format(status, errormsg)
+        shell: python
+        env:
+          STATUS: ${{ github.event.build.status }}
+          ERROR: ${{ github.event.build.error.message }}

--- a/.github/workflows/jekyll-diff.yml
+++ b/.github/workflows/jekyll-diff.yml
@@ -1,0 +1,12 @@
+name: Jekyll diff
+on: pull_request
+
+jobs:
+  diff-site:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: David-Byrne/jekyll-diff-action@v1.1.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I'm experimenting with GH Actions. This one does do much, it should only add the build page status on the CIs pass/fail message list.

~~PS: if I have the rights I'll self-merge this one so I can test it.~~

I do not have commit rights here :-(