### PR TITLE
remove version- from the site URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
     if [[ -z "$TRAVIS_TAG" ]]; then
       DEPLOY_DIR=dev
     else
-      DEPLOY_DIR="version-$TRAVIS_TAG"
+      DEPLOY_DIR="$TRAVIS_TAG"
     fi
     python -m doctr deploy --branch-whitelist source --build-tags --key-path github_deploy_key_oceanhackweek_oceanhackweek_github_io.enc --built-docs _site/ $DEPLOY_DIR
     python -m doctr deploy --branch-whitelist source --build-tags --key-path github_deploy_key_oceanhackweek_oceanhackweek_github_io.enc --built-docs _site/ .


### PR DESCRIPTION
This will publish the tag as https://oceanhackweek.github.io/ohw19/ instead of https://oceanhackweek.github.io/version-ohw19/