### PR TITLE
Style team badges and update history

### DIFF
--- a/_ext/ohw_team.py
+++ b/_ext/ohw_team.py
@@ -38,6 +38,7 @@ class OHWTeam(SphinxDirective):
     has_content = True
     option_spec = {
         "roles": directives.unchanged_required,
+        "hide_role_badges": directives.unchanged,
         "badges": directives.flag,
         "email_icon": directives.flag,
         "email_link": directives.flag,
@@ -45,6 +46,10 @@ class OHWTeam(SphinxDirective):
 
     def run(self):
         team = load_team_info()
+        try:
+            hide_role_badges = self.options["hide_role_badges"].split(",")
+        except KeyError:
+            hide_role_badges = []
 
         if self.options["roles"] == "all":
             members_in_roles = team
@@ -58,10 +63,10 @@ class OHWTeam(SphinxDirective):
 
                     for role in roles:
                         if any(
-                            [
+                            (
                                 fnmatch.fnmatch(member_role, role)
                                 for member_role in member_roles
-                            ]
+                            )
                         ):
                             members_in_roles.append(member)
                             continue
@@ -132,29 +137,38 @@ class OHWTeam(SphinxDirective):
                 body.append(badges)
                 try:
                     for role in member["roles"]:
-                        if role == "Steering Committee":
-                            color = "primary"
-                            outline = False
-                        elif (
-                            "Organizer" in role
-                            or "Instructor" in role
-                            or "Leader" in role
-                        ):
-                            color = "primary"
-                            outline = True
-                        elif "Participant" in role:
-                            color = "secondary"
-                            outline = True
-                        else:
-                            color = "secondary"
-                            outline = False
-
-                        badges.append(
-                            nodes.inline(
-                                text=role,
-                                classes=[*create_bdg_classes(color, outline), "mr-1"],
+                        if not any(
+                            (
+                                fnmatch.fnmatch(role, hide_role)
+                                for hide_role in hide_role_badges
                             )
-                        )
+                        ):
+                            if role == "Steering Committee":
+                                color = "primary"
+                                outline = False
+                            elif (
+                                "Organizer" in role
+                                or "Instructor" in role
+                                or "Leader" in role
+                            ):
+                                color = "primary"
+                                outline = True
+                            elif "Participant" in role:
+                                color = "secondary"
+                                outline = True
+                            else:
+                                color = "secondary"
+                                outline = False
+
+                            badges.append(
+                                nodes.inline(
+                                    text=role,
+                                    classes=[
+                                        *create_bdg_classes(color, outline),
+                                        "mr-1",
+                                    ],
+                                )
+                            )
                 except KeyError:
                     pass
 

--- a/_ext/ohw_team.py
+++ b/_ext/ohw_team.py
@@ -114,14 +114,33 @@ class OHWTeam(SphinxDirective):
                 link_wrapper.append(link)
                 body.append(link_wrapper)
 
+            # If badges should be shown, add and style them
             if "badges" in self.options:
                 badges = nodes.container(is_div=True)
                 body.append(badges)
                 try:
                     for role in member["roles"]:
+                        if role == "Steering Committee":
+                            color = "primary"
+                            outline = False
+                        elif (
+                            "Organizer" in role
+                            or "Instructor" in role
+                            or "Leader" in role
+                        ):
+                            color = "primary"
+                            outline = True
+                        elif "Participant" in role:
+                            color = "secondary"
+                            outline = True
+                        else:
+                            color = "secondary"
+                            outline = False
+
                         badges.append(
                             nodes.inline(
-                                text=role, classes=create_bdg_classes("primary", False)
+                                text=role,
+                                classes=[*create_bdg_classes(color, outline), "mr-1"],
                             )
                         )
                 except KeyError:

--- a/_ext/team.yaml
+++ b/_ext/team.yaml
@@ -4,12 +4,16 @@ team:
     affiliate: Development Seed
     image_url: https://developmentseed.org/static/4cedd143a50d1f6cfd7999ec017950ea/8a438/aimee.jpg
     github_user: abarciauskas-bgse
+    roles:
+      - OHW21 Organizer
 
   - name: Mathew Biddle
     title: Data Management Analyst
     affiliate: NOAA IOOS
     image_url: https://avatars.githubusercontent.com/u/8480023?v=4
     github_user: MathewBiddle
+    roles:
+      - OHW21 Organizer
 
   - name: Filipe Fernandes
     title: Research Software Engineer
@@ -18,7 +22,12 @@ team:
     github_user: ocefpaf
     roles:
       - Steering Committee
+      - Tutorials
       - Infrastructure
+      - OHW18 Organizer
+      - OHW19 Organizer
+      - OHW20 Organizer
+      - OHW21 Organizer
       - OHW22 Organizer - Florianopolis
 
   - name: Chelle Gentemann
@@ -26,12 +35,18 @@ team:
     affiliate: Farallon Institute
     image_url: https://images.squarespace-cdn.com/content/v1/56a6b01dd8af105db2511b83/1619046574422-KMBIXE9PYFBIXH9SN7CO/ke17ZwdGBToddI8pDm48kK60W-ob1oA2Fm-j4E_9NQB7gQa3H78H3Y0txjaiv_0fDoOvxcdMmMKkDsyUqMSsMWxHk725yiiHCCLfrh8O1z4YTzHvnKhyp6Da-NYroOW3ZGjoBKy3azqku80C789l0kD6Ec8Uq9YczfrzwR7e2Mh5VMMOxnTbph8FXiclivDQnof69TlCeE0rAhj6HUpXkw/ChelleIMG_7296.jpg
     github_user: cgentemann
+    roles:
+      - OHW20 Organizer
+      - OHW21 Organizer
 
   - name: Alison Gray
     title: Assistant Professor
     affiliate: UW School of Oceanography
     image_url: https://www.ocean.washington.edu/files/alisongray-2018-20180717023407_smsq.jpg
     github_user: alisonrgray
+    roles:
+      - OHW21 Organizer
+      - OHW22 Organizer
 
   - name: Joseph Gum
     title: Data Analyst
@@ -40,13 +55,20 @@ team:
     github_user: asx-
     roles:
       - Steering Committee
+      - Applicant Selection
+      - Projects
+      - OHW18 Participant
+      - OHW19 Organizer
+      - OHW20 Organizer
+      - OHW21 Organizer
       - OHW22 Organizer - Global
 
   - name: Charley Haley
     title: Organizational & Social Strategist
     affiliate: Back Loop Consulting Group
     image_url: https://media-exp1.licdn.com/dms/image/C5603AQHRrrm4VJcfBA/profile-displayphoto-shrink_200_200/0/1596141577546?e=1631750400&v=beta&t=0qoepteS1Git0uS5ObyTB5W38iyHbQZQbX2M7EUdjCU
-    github_user:
+    roles:
+      - OHW21 Organizer
 
   - name: Alex Kerney
     title: Web Application Developer
@@ -57,7 +79,8 @@ team:
     roles:
       - Steering Committee
       - Infrastructure
-      - OHW22 Organizer
+      - Website
+      - OHW20 Organizer
       - OHW21 Organizer - Maine
       - OHW22 Organizer - Maine
 
@@ -67,6 +90,10 @@ team:
     image_url: https://geohackweek.github.io/assets/images/JaneKoh.jpg
     roles:
       - Steering Committee
+      - OHW19 Organizer
+      - OHW20 Organizer
+      - OHW21 Organizer
+      - OHW22 Organizer
 
   - name: Wu-Jung Lee
     title: Senior Oceanographer
@@ -75,6 +102,14 @@ team:
     github_user: leewujung
     roles:
       - Steering Committee
+      - Applicant Selection
+      - Tutorials
+      - Financial Planning
+      - OHW18 Organizer
+      - OHW19 Organizer
+      - OHW20 Organizer
+      - OHW21 Organizer
+      - OHW22 Organizer - UW
 
   - name: Paige Martin
     title: Postdoctoral Researcher
@@ -83,6 +118,8 @@ team:
     github_user: paigem
     roles:
       - Steering Committee
+      - OHW21 Organizer - Australia
+      - OHW22 Organizer
 
   - name: Emilio Mayorga
     title: Senior Oceanographer
@@ -91,6 +128,13 @@ team:
     github_user: emiliom
     roles:
       - Steering Committee
+      - Applicant Selection
+      - OHW18 Organizer
+      - OHW19 Organizer
+      - OHW20 Organizer
+      - OHW21 Organizer
+      - OHW22 Organizer - UW
+      - OHW22 Organizer - Espanol
 
   - name: Catherine Mitchell
     title: Senior Research Scientist
@@ -100,6 +144,11 @@ team:
     email: cmitchell@bigelow.org
     roles:
       - Steering Committee
+      - Applicant Selection
+      - Tutorials
+      - Projects
+      - Financial Planning
+      - OHW20 Organizer
       - OHW21 Organizer - Maine
       - OHW22 Organizer - Maine
 
@@ -110,6 +159,11 @@ team:
     github_user: Thomas-Moore-Creative
     roles:
       - Steering Committee
+      - Projects
+      - Infrastructure
+      - Website
+      - OHW21 Organizer - Australia
+      - OHW22 Organizer
 
   - name: Nick Record
     title: Senior Research Scientist
@@ -118,3 +172,50 @@ team:
     github_user: SeascapeScience
     roles:
       - Steering Committee
+      - OHW20 Organizer
+      - OHW21 Organizer - Maine
+      - OHW22 Organizer
+
+  - name: Derya Gumustel
+    title: Data Analytics Instructor
+    affiliate: General Assembly
+    image_url: https://avatars.githubusercontent.com/u/51346322?v=4
+    github_user: dgumustel
+    roles:
+      - Steering Committee
+      - OHW21 Organizer
+      - OHW22 Organizer
+
+  - name: Nick Mortimer
+    title: Senior Engineer
+    affiliate: CSIRO Climate Science Centre, Australia
+    image_url: https://avatars.githubusercontent.com/u/4338975?v=4
+    github_user: NickMortimer
+    roles:
+      - Steering Committee
+      - OHW20 Participant
+      - OHW21 Organizer - Australia
+      - OHW22 Organizer - Australia
+
+  - name: Sophie Clayton
+    title: Assistant Professor of Oceanography
+    affiliate: Old Dominion University
+    image_url: https://avatars.githubusercontent.com/u/7740937?v=4
+    github_user: sophieclayton
+    roles:
+      - Steering Committee
+      - OHW20 Organizer
+      - OHW22 Organizer
+
+  # - name: Georgy Manucharyan
+  #   roles:
+  #     - OHW22 Organizer
+
+  # - name: Steve Diggs
+  #   title:
+  #   affiliate:
+  #   image_url:
+  #   github_user: sdiggs
+  #   roles:
+  #     - OHW22 Organizer - San Diego
+  #     - Financial Planning

--- a/_ext/team.yaml
+++ b/_ext/team.yaml
@@ -208,14 +208,19 @@ team:
       - OHW22 Organizer
 
   # - name: Georgy Manucharyan
-  #   roles:
-  #     - OHW22 Organizer
-
-  # - name: Steve Diggs
   #   title:
   #   affiliate:
   #   image_url:
-  #   github_user: sdiggs
+  #   github_user:
   #   roles:
-  #     - OHW22 Organizer - San Diego
-  #     - Financial Planning
+  #     - OHW22 Organizer
+
+  - name: Steve Diggs
+    title: Data Manager
+    affiliate: Scripps Institution of Oceanography
+    image_url: https://scripps.ucsd.edu/sites/default/files/profilePhoto/diggs_web.jpg
+    github_user: sdiggs
+    roles:
+      - Financial Planning
+      - OHW21 Participant
+      - OHW22 Organizer - San Diego

--- a/about/steering_committee.md
+++ b/about/steering_committee.md
@@ -9,4 +9,5 @@ description: Team of OceanHackWeek organizers
 ```{ohw-team}
 :roles: Steering Committee
 :badges:
+:hide_role_badges: "OHW18 O*,OHW19 O*,OHW20 O*,OHW21 O*"
 ```

--- a/ohw22/index.md
+++ b/ohw22/index.md
@@ -22,9 +22,9 @@ The **Global Virtual Event** will take place 3 hours per day over a 5-day period
 
 *ONE SENTENCE ABOUT THE UW UG PROGRAM HERE*
 
-## OHW22 organizers
+## [OHW22 organizers](./organizers.md)
 
-Mention the OHW22 organizing committee here, and link to the dedicated OHW team page (if we go that route). Maybe encourage people to help, include the OHW contact email address.
+Mention the OHW22 organizing committee here, and [link to the dedicated OHW team page](./organizers.md) (if we go that route). Maybe encourage people to help, include the OHW contact email address.
 
 
 ```{toctree}

--- a/ohw22/index.md
+++ b/ohw22/index.md
@@ -34,4 +34,5 @@ Mention the OHW22 organizing committee here, and link to the dedicated OHW team 
 applicants
 satellites
 maine/index
+organizers
 ```

--- a/ohw22/organizers.md
+++ b/ohw22/organizers.md
@@ -3,5 +3,4 @@
 ```{ohw-team}
 :roles: "OHW22 Organizer*"
 :badges:
-:email_icon:
 ```

--- a/ohw22/organizers.md
+++ b/ohw22/organizers.md
@@ -3,4 +3,5 @@
 ```{ohw-team}
 :roles: "OHW22 Organizer*"
 :badges:
+:hide_role_badges: "OHW18 O*,OHW19 O*,OHW20 O*,OHW21 O*,Steering Committee,Tutorials,Infrastructure,Applicant Selection,Projects,Financial Planning,Website"
 ```

--- a/ohw22/organizers.md
+++ b/ohw22/organizers.md
@@ -1,0 +1,7 @@
+# OHW22 Organizers
+
+```{ohw-team}
+:roles: "OHW22 Organizer*"
+:badges:
+:email_icon:
+```


### PR DESCRIPTION
Adds different styling for badges for team members depending if they are on the steering committee, part of a task team, participant, or organizer.

I also tried to go back and dig through the old sites and Github team membership to include everyone's involvement. Please let me know if there are any changes that I should make for folk's roles.

![image](https://user-images.githubusercontent.com/1296209/166962994-03df0242-c4b6-48c8-92f9-b15b8ff0fb9d.png)
