### PR TITLE
Move the Maine event under satellites in the toctree

### DIFF
--- a/ohw22/index.md
+++ b/ohw22/index.md
@@ -33,5 +33,4 @@ Mention the OHW22 organizing committee here, and link to the dedicated OHW team 
 
 applicants
 satellites
-maine/index
 ```

--- a/ohw22/maine/index.md
+++ b/ohw22/maine/index.md
@@ -1,4 +1,4 @@
-# US - East
+# US East
 
 This year we are having two parallel East Coast events in Maine.
 One event will be held at Bigelow Labs in Boothbay, and the other at Gulf of Maine Research Institute in Portland

--- a/ohw22/satellites.md
+++ b/ohw22/satellites.md
@@ -8,7 +8,7 @@ The satellite events may be virtual or in-person and take different formats depe
 
 *Location, Time zone, Link to detail page, format (virtual vs hybrid vs in-person)*
 
-## US East (UTC-4)
+## [US East](./maine/index) (UTC-4)
 
 - Format: informal in-person gatherings
 - Locations: East Boothbay (Bigelow Laboratory for Ocean Sciences) and Portland (Gulf of Maine Research Institute), Maine, US.
@@ -50,3 +50,11 @@ The satellite events may be virtual or in-person and take different formats depe
 - Format: virtual + small in-person gatherings
 - Location: Lima, Peru and Rocha, Uruguay
 - In Spanish / bilingual
+
+
+```{toctree}
+:maxdepth: 2
+:hidden:
+
+maine/index
+```


### PR DESCRIPTION
Additionally I linked the event header on satellites to the page

<img width="496" alt="image" src="https://user-images.githubusercontent.com/1296209/166969266-cad71239-b517-4e20-9936-89ea6a15be0d.png">

I also tested that we could have another level of pages nested underneath:

<img width="338" alt="image" src="https://user-images.githubusercontent.com/1296209/166969468-ef200119-314b-4161-8eaa-ccb59b80c85f.png">
