### PR TITLE
Rename Maine event from US East to US Northeast

### DIFF
--- a/ohw22/maine/index.md
+++ b/ohw22/maine/index.md
@@ -1,4 +1,4 @@
-# US East
+# US Northeast
 
 This year we are having two parallel East Coast events in Maine.
 One event will be held at Bigelow Labs in Boothbay, and the other at Gulf of Maine Research Institute in Portland


### PR DESCRIPTION
Following changes in #131 in event naming the Maine satellite to US Northeast rather than US East.