### PR TITLE
Add minimal info and main contacts to satellite page

### DIFF
--- a/_ext/team.yaml
+++ b/_ext/team.yaml
@@ -20,6 +20,7 @@ team:
     affiliate: NOAA IOOS
     image_url: https://oceanhackweek.github.io/assets/images/filipe.jpg
     github_user: ocefpaf
+    email: ocefpaf@gmail.com
     roles:
       - Steering Committee
       - Tutorials

--- a/ohw22/brazil/index.md
+++ b/ohw22/brazil/index.md
@@ -1,4 +1,4 @@
-# UFSC Satellite
+# UFSC Satellite (Florianópolis, Brazil)
 
 ​
 ## Location

--- a/ohw22/brazil/index.md
+++ b/ohw22/brazil/index.md
@@ -1,7 +1,5 @@
 # UFSC Satellite
 
-This year we are having two parallel East Coast events in Maine.
-One event will be held at Bigelow Labs in Boothbay, and the other at Gulf of Maine Research Institute in Portland
 ​
 ## Location
 ​

--- a/ohw22/brazil/index.md
+++ b/ohw22/brazil/index.md
@@ -1,0 +1,30 @@
+# UFSC Satellite
+
+This year we are having two parallel East Coast events in Maine.
+One event will be held at Bigelow Labs in Boothbay, and the other at Gulf of Maine Research Institute in Portland
+​
+## Location
+​
+USFC, Florianópolis, Santa Catarina, Brazil
+​
+## Format: In-person
+​
+We plan to reserve a room at the university of Florianópolis to watch the tutorials and work on the project. 
+However, we will allow students to participate remotely in case they are not conformable with the in person setup.
+
+## Applicants profile: Local students
+
+The goal is to give local students who believe are not ready to apply to the main OHW, or applied multiple times and were not selected, a chance to participate.
+
+## Summary
+​
+1. We will watch all the broadcasted tutorials
+2. The project will be a hack session with a local buoy data
+2. We will encourage students to communicate with the main event and other satellite events to augment their OHW experience.
+
+## Organizers
+
+```{ohw-team}
+:roles: OHW22 Organizer - Florianopolis
+:email_icon:
+```

--- a/ohw22/satellites.md
+++ b/ohw22/satellites.md
@@ -51,7 +51,7 @@ Details of the event are still being flushed out. Check back here soon for more 
 
 We will have limited support available for regional participants needing to travel.
 
-Details of the event are still being flushed out, including the exact location. Check back here soon for more info!
+Details of the event are still being fleshed out, including the exact location. Check back here soon for more info!
 
 
 

--- a/ohw22/satellites.md
+++ b/ohw22/satellites.md
@@ -58,7 +58,7 @@ Details of the event are still being fleshed out, including the exact location. 
 ## Brazil
 
 - Time zone: UTC-3
-- Format: virtual gathering
+- Format: in-person gathering + virtual
 - Location: Florianópolis, Santa Catarina, Brazil
 - **See [more details and contact info here.](./brazil/index)**
 

--- a/ohw22/satellites.md
+++ b/ohw22/satellites.md
@@ -37,13 +37,23 @@ These two sub-programs are coordinated in their planning and coincides in time. 
 - Time zone: UTC-7 (US/Pacific)
 - Format: informal in-person gathering
 - Location: San Diego (Scripps Institution of Oceanography), California, USA
+- Main contact: Steve Diggs (sdiggs@ucsd.edu)
+
+Details of the event are still being flushed out. Check back here soon for more info!
+
 
 ## Australia
 
 - Time zone: UTC+10
 - Format: informal in-person gathering
-- Location: TBD
-- Limited logistic support available for regional participants needing to travel. See PAGE for detail.
+- Location: TBD, likely near Brisbane
+- Main contact: Nick Mortimer (Nick.Mortimer@csiro.au)
+
+We will have limited support available for regional participants needing to travel.
+
+Details of the event are still being flushed out, including the exact location. Check back here soon for more info!
+
+
 
 ## Brazil
 
@@ -52,12 +62,15 @@ These two sub-programs are coordinated in their planning and coincides in time. 
 - Location: Florianópolis, Santa Catarina, Brazil
 - **See [more details and contact info here.](https://hackmd.io/ZXHFGQwvRXSrzRV6rdwYNg?view)**
 
+
 ## OHW-Español
 
 - Time zone: UTC-4
 - Format: virtual + small in-person gatherings
-- Location: Lima, Peru and Rocha, Uruguay
-- In Spanish / bilingual
+- Locations: Lima, Peru and Rocha, Uruguay
+- Main contact: Emilio Mayorga (emiliom@uw.edu).
+
+Details of the event are still being flushed out, including the exact venues at the two locations. Check back here soon for more info!
 
 
 ```{toctree}

--- a/ohw22/satellites.md
+++ b/ohw22/satellites.md
@@ -39,7 +39,7 @@ These two sub-programs are coordinated in their planning and coincides in time. 
 - Location: San Diego (Scripps Institution of Oceanography), California, USA
 - Main contact: Steve Diggs (sdiggs@ucsd.edu)
 
-Details of the event are still being flushed out. Check back here soon for more info!
+Details of the event are still being fleshed out. Check back here soon for more info!
 
 
 ## Australia

--- a/ohw22/satellites.md
+++ b/ohw22/satellites.md
@@ -60,7 +60,7 @@ Details of the event are still being flushed out, including the exact location. 
 - Time zone: UTC-3
 - Format: virtual gathering
 - Location: Florianópolis, Santa Catarina, Brazil
-- **See [more details and contact info here.](https://hackmd.io/ZXHFGQwvRXSrzRV6rdwYNg?view)**
+- **See [more details and contact info here.](./brazil/index)**
 
 
 ## OHW-Español
@@ -80,4 +80,5 @@ Details of the event are still being flushed out, including the exact venues at 
 
 maine/index
 seattle/index
+Brazil <brazil/index>
 ```


### PR DESCRIPTION
Thinking it's good to have minimal and list main contacts for now, when details are being flushed out.

This builds on top of changes in #135. (in retrospect probably not a smart choice... )