### PR TITLE
Update team info, application FAQ, Australia satellite info

### DIFF
--- a/_ext/team.yaml
+++ b/_ext/team.yaml
@@ -48,7 +48,7 @@ team:
     github_user: alisonrgray
     roles:
       - OHW21 Organizer
-      - OHW22 Organizer - UW UG
+      - OHW22 Organizer - Seattle UG
 
   - name: Joseph Gum
     title: Data Analyst
@@ -100,7 +100,7 @@ team:
   - name: Wu-Jung Lee
     title: Senior Oceanographer
     affiliate: UW Applied Physics Laboratory
-    image_url: https://leewujung.github.io/img/wjlee_pic-01.jpg
+    image_url: https://uw-echospace.github.io/author/wu-jung-lee/avatar_hue32bd5ea14559ee6625b974cf92f99ba_1703649_270x270_fill_q90_lanczos_center.jpg
     github_user: leewujung
     email: leewj@uw.edu
     roles:
@@ -112,7 +112,7 @@ team:
       - OHW19 Organizer
       - OHW20 Organizer
       - OHW21 Organizer
-      - OHW22 Organizer - UW
+      - OHW22 Organizer - Seattle
 
   - name: Paige Martin
     title: Postdoctoral Researcher
@@ -138,7 +138,7 @@ team:
       - OHW19 Organizer
       - OHW20 Organizer
       - OHW21 Organizer
-      - OHW22 Organizer - UW
+      - OHW22 Organizer - Seattle
       - OHW22 Organizer - Espanol
 
   - name: Catherine Mitchell
@@ -189,7 +189,7 @@ team:
     roles:
       - Steering Committee
       - OHW21 Organizer
-      - OHW22 Organizer - UW
+      - OHW22 Organizer - Seattle
 
   - name: Nick Mortimer
     title: Senior Engineer
@@ -220,7 +220,7 @@ team:
     github_user: 
     email: gmanuch@uw.edu
     roles:
-      - OHW22 Organizer - UW UG
+      - OHW22 Organizer - Seattle UG
 
   - name: Steve Diggs
     title: Data Manager

--- a/ohw22/applicants.md
+++ b/ohw22/applicants.md
@@ -14,7 +14,6 @@ The OceanHackWeek program consists of hands-on tutorials, visual presentations, 
 ```{admonition} Applications for OHW22 are now open!
 :class: important
 
-Applications opened on May 9. 
 **To apply, please [fill out this form](https://form.jotform.com/221166776095160) by the end of June 1, 2022.**  
 Accepted applicants will be notified no later than June 18, 2022.
 ```
@@ -54,7 +53,7 @@ We expect all participants to be engaged in the team projects and focus during t
 
 ### Q: I am an undergraduate, and I'm not sure I'm ready for this
 
-This year (2022) we have a special, enriched program for undergraduates! The "Data Science in Oceanography" program at the University of Washington will provide opportunities for undergraduate students in data-driven research in oceanography. Participating students will interact closely with faculty and graduate student mentors to develop and advance individual research projects. Students will fully participate in the OHW Northwest satellite event as part of this 3-week long undergraduate program. See [here for details](seattle/index).
+This year (2022) we have a special, enriched program for undergraduates! The "Data Science in Oceanography" program at the University of Washington (Seattle, WA) will provide opportunities for undergraduate students in data-driven research in oceanography. Participating students will interact closely with faculty and graduate student mentors to develop and advance individual research projects. Students will fully participate in the OHW Northwest satellite event as part of this 3-week long undergraduate program, with the regular OHW activites in the second week. See [here for details](seattle/index).
 
 ### Q: I am proficient in Matlab / other languages but have not used Python or R. Python or R has been on my list to learn. How can I make my application be stronger?
 
@@ -69,7 +68,7 @@ Participants should familiarize themselves with the materials included in [Pytho
 
 ### Q: I don't know the first thing about version revision/control systems. Can I still apply?
 
-During the hackweek we will use Git and GitHub but you are not expected to be an expert on it. Again we recommend the [Software Carpentry lessons](https://swcarpentry.github.io/git-novice/) for git.
+During the hackweek we will use Git and GitHub but you are not expected to be an expert on it. In previous years we have offered refresher in the week prior to the actual OHW event. The organizing committee is deciding whether we can offer this in OHW22. You are welcome to check back here for this info, but we want to emphasize that nothing is better than trying it yourself first -- we recommend the [Software Carpentry lessons](https://swcarpentry.github.io/git-novice/) for learning git basic. 
 
 Note that we will require you to create a [GitHub account](https://github.com/) before completing the application.
 

--- a/ohw22/australia/index.md
+++ b/ohw22/australia/index.md
@@ -2,17 +2,19 @@
 
 ## Location
 
-TBD, likely near Brisbane
+Stradbroke Island, Brisbane, AU
 
-## Format: informal in-person gathering
+## Format: in-person
 
-## Applicants profile:
+We are planning for an in-person satellite event with approximately 10-12 participants. We'll watch tutorials together and work on projects within the group and also with participants in other satellites.
 
-## Summary
+<!-- ## Applicants profile: -->
 
-We will have limited support available for regional participants needing to travel.
+## Logistics
 
-Details of the event are still being fleshed out, including the exact location. Check back here soon for more info!
+We will have limited support available for regional participants needing to travel. Details of the event are still being fleshed out. Check back here soon for more info!
+
+If there is specific information you are looking for that will help you make application decisions, feel free to email the event organizer.
 
 ## Organizers
 

--- a/ohw22/satellites.md
+++ b/ohw22/satellites.md
@@ -46,11 +46,8 @@ Details of the event are still being fleshed out. Check back here soon for more 
 ## Australia
 
 - Time zone: UTC+10
-- Format: informal in-person gathering
-- Location: TBD, likely near Brisbane
-We will have limited support available for regional participants needing to travel.
-
-Details of the event are still being fleshed out, including the exact location. Check back here soon for more info!
+- Format: in-person gathering
+- Location: Stradbroke Island, Brisbane, Australia
 
 **See [more details and contact info here.](./australia/index)**
 

--- a/ohw22/seattle/index.md
+++ b/ohw22/seattle/index.md
@@ -52,7 +52,7 @@ For questions specific to the undergraduate summer program, please email Dr. Geo
 ## Organizers
 
 ```{ohw-team}
-:roles: OHW22 Organizer - UW*
+:roles: OHW22 Organizer - Seattle*
 :email_icon:
 ```
 


### PR DESCRIPTION
This PR is overloaded but seems the best path given the time:
- Update team info
  - change `UW` to `Seattle` to conform with other satellite
  - @leewujung pic change
- Update Australia satellite entry with location and participant number info
- Minor tweak of application FAQ
