### PR TITLE
Linking to discussions

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -64,6 +64,11 @@ html_theme_options = {
             "icon": "fab fa-github-square",
         },
         {
+            "name": "Discussions",
+            "url": "https://github.com/orgs/oceanhackweek/discussions",
+            "icon": "fas fa-comments",
+        },
+        {
             "name": "Twitter",
             "url": "https://twitter.com/oceanhackweek",
             "icon": "fab fa-twitter-square",

--- a/ohw22/applicants.md
+++ b/ohw22/applicants.md
@@ -19,9 +19,9 @@ Accepted applicants will be notified no later than June 18, 2022.
 ```
 
 Please see the FAQs below for answers to common questions.
-For additional questions, please email 
+For additional questions, please post in our [discussions on Github](https://github.com/orgs/oceanhackweek/discussions/categories/q-a) or email 
 <a href="mailto:oceanhkw@uw.edu" target="_blank">oceanhkw@uw.edu</a>.
-For satellite event-specific questions, please contact satellite organizers listed in the main [Regional Satellites page](satellites) or in the individual event pages.
+For satellite event-specific questions, please post in the discussions, or contact satellite organizers listed in the individual event pages.
 
 **If you are applying for the undergraduate summer program “Data Science in Oceanography”** that will take place on August 8-26, 2022 in coordination with the US Northwest OHW satellite, see [this page](seattle/index) for more information and apply using the same OHW form.
 
@@ -31,7 +31,7 @@ For satellite event-specific questions, please contact satellite organizers list
 
 ### Q: The satellite event in my region doesn't have a lot of details yet, what should I do?
 
-Some regional satellite organizers are still fleshing out details of the event, including the exact location. Feel free to email them if there is specific information you need from them for you to make decisions on your application.
+Some regional satellite organizers are still fleshing out details of the event, including the exact location. Feel free to ask in [Github Discussions](https://github.com/orgs/oceanhackweek/discussions/categories/q-a) or email them if there is specific information you need from them for you to make decisions on your application.
 
 ### Q: I am an undergrad / first year grad / faculty / etc. Is this program right for me?
 

--- a/ohw22/australia/index.md
+++ b/ohw22/australia/index.md
@@ -16,7 +16,9 @@ We will have limited support available for regional participants needing to trav
 
 Details of the event are still being fleshed out. Check back here soon for more info!
 
-If there is specific information you are looking for that will help you make application decisions, feel free to email the event organizer.
+If there is specific information you are looking for that will help you make application decisions, please ask them in [Github Discussions](https://github.com/orgs/oceanhackweek/discussions/categories/q-a?discussions_q=category%3AQ%26A+label%3A%22OHW22+-+Australia%22).
+Please tag the organizers with `@oceanhackweek/ohw22-organizers-australia` and add a `OHW22 - Australia` label so that others can find answers about the satellite.
+Additionally, please feel free to email the event organizer.
 
 ## Organizers
 

--- a/ohw22/brazil/index.md
+++ b/ohw22/brazil/index.md
@@ -26,3 +26,6 @@ The goal is to give local students who believe are not ready to apply to the mai
 :roles: OHW22 Organizer - Florianopolis
 :email_icon:
 ```
+
+If you have general questions about the event at UFSC, please ask them in [Github Discussions](https://github.com/orgs/oceanhackweek/discussions/categories/q-a?discussions_q=category%3AQ%26A+label%3A%22OHW22+-+Brazil%22).
+Please tag the organizers with `@oceanhackweek/ohw22-organizers-brazil` and add a `OHW22 - Brazil` label so that others can find answers about the satellite.

--- a/ohw22/espanol/index.md
+++ b/ohw22/espanol/index.md
@@ -39,3 +39,6 @@ The in-person gatherings are intended for local participants. The online gatheri
 :roles: OHW22 Organizer - Espanol
 :email_icon:
 ```
+
+If you have general questions about the Español satellite, please ask them in [Github Discussions](https://github.com/orgs/oceanhackweek/discussions/categories/q-a?discussions_q=category%3AQ%26A+label%3A%22OHW22+-+Espa%C3%B1ol%22).
+Please tag the organizers with `@oceanhackweek/ohw22-organizers-espanol` and add a `OHW22 - Espanol` label so that others can find answers about the satellite.

--- a/ohw22/maine/index.md
+++ b/ohw22/maine/index.md
@@ -1,7 +1,7 @@
 # US Northeast
 
 This year we are having two parallel East Coast events in Maine.
-One event will be held at Bigelow Labs in Boothbay, and the other at Gulf of Maine Research Institute in Portland
+One event will be held at Bigelow Labs in Boothbay, and the other at the Gulf of Maine Research Institute in Portland
 ​
 ## Location
 ​
@@ -30,3 +30,7 @@ We welcome participants from all career stages and encourage applications from g
 :roles: OHW22 Organizer - Maine
 :email_icon:
 ```
+
+If you have general questions about the events at Bigelow or the Gulf of Maine Research Institute, please ask them in [Github Discussions](https://github.com/orgs/oceanhackweek/discussions/categories/q-a?discussions_q=category%3AQ%26A+label%3A%22OHW22+-+Northeast%22). 
+Please the organizers with `@oceanhackweek/ohw22-organizers-northeast` and add a `OHW22 - Northeast` label so that others can find answers about our satellite.
+You are also welcome to reach out to us by email.

--- a/ohw22/san-diego/index.md
+++ b/ohw22/san-diego/index.md
@@ -12,7 +12,9 @@ Scripps Institution of Oceanography, San Diego, CA
 
 Details of the event are still being fleshed out. Check back here soon for more info!
 
-If there is specific information you are looking for that will help you make application decisions, feel free to email the event organizer.
+If there is specific information you are looking for that will help you make application decisions, please ask them in [Github Discussions](https://github.com/orgs/oceanhackweek/discussions/categories/q-a?discussions_q=category%3AQ%26A+label%3A%22OHW22+-+Southwest%22).
+Please tag the organizers with `@oceanhackweek/ohw22-organizers-southwest` and add a `OHW22 - Southwest` label so that others can find answers about the satellite.
+Additionally, please feel free to email the event organizer.
 
 ## Organizers
 

--- a/ohw22/seattle/index.md
+++ b/ohw22/seattle/index.md
@@ -31,7 +31,7 @@ We are able to provide lodging for a small number of participants who need to tr
 
 **Contact**
 
-For questions specific to the regular OHW satellite, please email Dr. Wu-Jung Lee (leewj@uw.edu).
+For questions specific to the regular OHW satellite, please ask in our [Github Discussions](https://github.com/orgs/oceanhackweek/discussions/categories/q-a?discussions_q=category%3AQ%26A+label%3A%22OHW22+-+Northwest%22). Please tag the organizers with `@oceanhackweek/ohw22-organizers-northwest` and add a `OHW22 - Northwest` label so that others can find answers. Additionally you can email Dr. Wu-Jung Lee (leewj@uw.edu).
 
 
 ## Undergraduate summer program (August 8-26, 2022)


### PR DESCRIPTION
https://github.com/orgs/oceanhackweek/discussions

- Icon at top right
- Link from satellite applicants and individual satellite pages
- Labels and teams setup for all satellites

xref: oceanhackweek/admin#27