### PR TITLE
Task group page

### DIFF
--- a/_ext/team.yaml
+++ b/_ext/team.yaml
@@ -23,6 +23,7 @@ team:
     email: ocefpaf@gmail.com
     roles:
       - Steering Committee
+      - Application Selection
       - Tutorials
       - Infrastructure
       - OHW18 Organizer
@@ -138,6 +139,7 @@ team:
       - Steering Committee
       - Applicant Selection
       - Website
+      - Financial Planning
       - OHW18 Organizer
       - OHW19 Organizer
       - OHW20 Organizer
@@ -168,9 +170,6 @@ team:
     github_user: Thomas-Moore-Creative
     roles:
       - Steering Committee
-      - Projects
-      - Infrastructure
-      - Website
       - OHW21 Organizer - Australia
       - OHW22 Organizer - Global
 
@@ -192,6 +191,7 @@ team:
     github_user: dgumustel
     roles:
       - Steering Committee
+      - Tutorials
       - OHW21 Organizer
       - OHW22 Organizer - Seattle
 
@@ -214,6 +214,7 @@ team:
     github_user: sophieclayton
     roles:
       - Steering Committee
+      - Projects
       - OHW20 Organizer
       - OHW22 Organizer - Global
 
@@ -266,3 +267,13 @@ team:
     roles:
       - OHW20 Participant
       - OHW22 Organizer - Espanol
+
+  - name: Nora Loose
+    title: Postdoc
+    affiliate: University of Colorado, Boulder
+    image_url: https://avatars.githubusercontent.com/u/23617395?v=4
+    github_user: NoraLoose
+    email: nora.loose@gmail.com
+    roles:
+      - Projects
+      - OHW20 Participant

--- a/about/index.md
+++ b/about/index.md
@@ -50,6 +50,7 @@ The hackweek model was spearheaded by the successful [*Astro-*](http://astrohack
 :hidden:
 
 steering_committee
+task-groups
 pasthackweeks
 code-of-conduct
 ```

--- a/about/task-groups.md
+++ b/about/task-groups.md
@@ -1,0 +1,52 @@
+# Task Groups
+
+In order to make OceanHackWeek happen each year, we've found that we have a few core sets of tasks.
+
+Accordingly we organize ourselves around those tasks, both so that we have a smaller number of folks to make decisions, but also to make it easier to know who to talk to about any issues.
+
+Most of these groups have or will have Github teams & Slack user group or channel that you can use to communicate with them.
+
+## Tutorials
+
+```{ohw-team}
+:roles: Tutorials
+:email_icon:
+```
+
+## Projects
+
+```{ohw-team}
+:roles: Projects
+:email_icon:
+```
+
+## Financial Planning
+
+```{ohw-team}
+:roles: Financial Planning
+:email_icon:
+```
+
+## Participant Application & Selection
+
+```{ohw-team}
+:roles: Applicant Selection
+:email_icon:
+```
+
+## Website and Communication
+
+```{ohw-team}
+:roles: Website
+:email_icon:
+```
+
+## Infrastructure
+
+- Github: @gulfofmaine/infrastructure
+- Slack: @help-infrastructure
+
+```{ohw-team}
+:roles: Infrastructure
+:email_icon:
+```

--- a/about/task-groups.md
+++ b/about/task-groups.md
@@ -8,12 +8,22 @@ Most of these groups have or will have Github teams & Slack user group or channe
 
 ## Tutorials
 
+Developing the flow of the week and figuring out what is key for us to teach and show.
+
+- Github: [@oceanhackweek/tutorials](https://github.com/orgs/oceanhackweek/teams/tutorials)
+- Slack: @help-tutorials
+
 ```{ohw-team}
 :roles: Tutorials
 :email_icon:
 ```
 
 ## Projects
+
+Wrangling all the crazy ideas that our participants & leaders have.
+
+- Github: [@oceanhackweek/projects](https://github.com/orgs/oceanhackweek/teams/projects)
+- Slack: @help-projects
 
 ```{ohw-team}
 :roles: Projects
@@ -22,6 +32,10 @@ Most of these groups have or will have Github teams & Slack user group or channe
 
 ## Financial Planning
 
+If you'd like to give us money to help OceanHackWeek keep happening, or you've got an idea where to find some, let this team know.
+
+- Slack: @financial-planning
+
 ```{ohw-team}
 :roles: Financial Planning
 :email_icon:
@@ -29,12 +43,18 @@ Most of these groups have or will have Github teams & Slack user group or channe
 
 ## Participant Application & Selection
 
+The participant application and selection team develops the application process and form, and provides criteria for selection of participants.
+
 ```{ohw-team}
 :roles: Applicant Selection
-:email_icon:
 ```
 
 ## Website and Communication
+
+This team manages the website and some of the other outward communication.
+
+- Github: [@oceanhackweek/website](https://github.com/orgs/oceanhackweek/teams/website/discussions)
+- Slack: @help-website
 
 ```{ohw-team}
 :roles: Website
@@ -43,8 +63,10 @@ Most of these groups have or will have Github teams & Slack user group or channe
 
 ## Infrastructure
 
-- Github: @gulfofmaine/infrastructure
-- Slack: @help-infrastructure
+The infrastructure team manages GitHub, JupyterHub, and Slack.
+
+- Github: [@oceanhackweek/infrastructure](https://github.com/orgs/oceanhackweek/teams/infrastructure)
+- Slack: @help-infrastructure and 
 
 ```{ohw-team}
 :roles: Infrastructure


### PR DESCRIPTION
Add a page for task groups and update to match the current state of https://github.com/oceanhackweek/admin-ohw22/issues/11

Additionally created and populated Github and Slack teams as needed.