### PR TITLE
New testimonials page and richer Past OHW Events content

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -52,5 +52,6 @@ The hackweek model was spearheaded by the successful [*Astro-*](http://astrohack
 steering_committee
 task-groups
 pasthackweeks
+Testimonials <testimonials>
 code-of-conduct
 ```

--- a/about/pasthackweeks.md
+++ b/about/pasthackweeks.md
@@ -11,60 +11,38 @@ OceanHackWeek (**OHW**) has taken place annually starting in 2018. Materials fro
 
 OceanHackWeek started out as an in-person event in Seattle with limited virtual access in 2018 and 2019, but moved to a virtual format in 2020 and a hybrid format in 2021.
 
+See [Testimonials](testimonials) for quotes from past participants.
+
 ## 2021 (OHW21)
 
+- A hybrid event with 70 participants, including 19 in-person participants at the Bigelow Laboratory for Ocean Sciences, East Boothbay, Maine
+- 7 tutorials + [11 projects](https://oceanhackweek.github.io/ohw-resources/projects/projectlist/)
+- Programming languages: Python + R
 - [Web site](https://oceanhackweek.github.io/ohw21/)
-- [OHW Resources site](https://oceanhackweek.github.io/ohw-resources/)
+- [OHW21 Resources site](https://oceanhackweek.github.io/ohw-resources/)
 - [Schedule](https://oceanhackweek.github.io/ohw-resources/schedule/#main-virtual-event). Links to tutorials are found here.
-- [Projects](https://oceanhackweek.github.io/ohw-resources/projects/projectlist/)
 
 ## 2020 (OHW20)
 
+- A virtual event with 46 participants
+- 10 tutorials + [8 projects](https://oceanhackweek.github.io/ohw21/projects_2020.html)
+- Programming languages: Python + R
 - [Web site](https://oceanhackweek.github.io/ohw20/)
-- [OHW Resources site](https://oceanhackweek.github.io/ohw-resources/ohw20/)
+- [OHW20 Resources site](https://oceanhackweek.github.io/ohw-resources/ohw20/)
 - [Schedule](https://oceanhackweek.github.io/ohw-resources/ohw20/schedule/). Links to tutorials are found here.
-- [Projects](https://oceanhackweek.github.io/ohw21/projects_2020.html)
 
 ## 2019 (OHW19)
 
+- An in-person event with 54 participants at the University of Washington, Seattle, Washington
+- 8 tutorials + [11 projects](https://oceanhackweek.github.io/ohw19/projects_2019.html)
+- Programming languages: Python
 - [Web site](https://oceanhackweek.github.io/ohw19/)
-- [Schedule](https://oceanhackweek.github.io/ohw19/curriculum_2019.html)
-- [Projects](https://oceanhackweek.github.io/ohw19/projects_2019.html)
+- [Schedule](https://oceanhackweek.github.io/ohw19/curriculum_2019.html). Links to tutorials are found here.
 
 ## 2018 (OHW18)
 
+- An in-person event with 52 participants at the University of Washington, Seattle, Washington
+- 13 tutorials + [11 projects](https://oceanhackweek.github.io/ohw2018/projects.html)
+- Programming languages: Python
 - [Web site](https://oceanhackweek.github.io/ohw2018/)
-- [Schedule](https://oceanhackweek.github.io/ohw2018/schedule.html)
-- [Projects](https://oceanhackweek.github.io/ohw2018/projects.html)
-
-## Participant quotes from previous OHW events
-
-```{epigraph}
-My experience at the Oceanhackweek 2019 was in a few words a once in a lifetime learning experience. The people involved were amazing, from the organization group to all the participants. The project group I joined was extremely democratic and involved. I learned not only from more advanced researchers but also telling what I knew to my group partners. I definitely recommend this event for everyone that is eager to learn.
-
--- Ágata Piffer Braga, 2019
-```
-
-```{epigraph}
-I feel so lucky that I didn't miss the brainstorm of the data techniques in OHW2019. I have been using python for data analysis abut two years. [...] And I was quite satisfied with Python packages [...] which are extensively used in my data analysis for numerical model outputs. So when I heard about Oceanhackweek, I expected that probably I could meet more Python fellows in the ocean community, and it will be very beneficial to stay in a community for debugging and learn new staff in future works. Actually, the week spent in OHW2019 paid me much more than I could ever have expected. Packages, such as xarray and Dask, expanded my vision on python’s applications in ocean data analysis. Lectures on Github opened the door of so many repositories of open-source projects. Pangeo provided a cutting-edge platform for oceanographers to use packages specifically written for ocean data. Cloud data storage and cloud computation demonstrated great potential for ocean researches. And the project work during the workshop really makes our hands dirty in using the techniques we learned. Our team worked on quality control using machine-learning methods. It was a lot of cooperation, hardworking, fun, and friendships.
-
--- Xu Chen, 2019
-```
-
-```{epigraph}
-The workshop provided an excellent introduction to the existing infrastructure of oceanographic data-gathering resources. Also provided was an introduction to the open-source evolving tools for accessing and utilizing large data sets. The technical challenges in data-intensive research are daunting, and here this workshop’s model and enactment of collaborative work was particularly valuable to me.
-
--- Rachel Jackson, San Francisco State University, 2018
-```
-
-```{epigraph}
-I am grateful to have attended Oceanhackweek, and to have been given the opportunity to expand my skill set in such a productive and pleasant environment. I live in Fairbanks, AK, where we are rather isolated and aren't naturally exposed to new tools or methods. [...] Oceanhackweek gave me that time, introduced me to possibilities via the tutorials, and through the projects produced a technical structure that I can apply to our research in Alaska.
-
--- Liz Dobbins, University of Alaska, Fairbanks, 2018
-```
-
-```{epigraph}
-It is sometimes hard to predict whether a given conference, training or hack-a-thon might be worth your time. [...] The real challenge, of course, is to find a group of like minded people that want to expand their horizons and learn together, and that is just what I found when I attended Ocean Hackweek.
-
--- Christian Saranson, 2018
-```
+- [Schedule](https://oceanhackweek.github.io/ohw2018/schedule.html). Links to tutorials are found here.

--- a/about/testimonials.md
+++ b/about/testimonials.md
@@ -1,0 +1,91 @@
+# Testimonials from previous participants
+
+## OHW21 (Hybrid)
+
+```{epigraph}
+As a rising senior in university, attending Ocean Hackweek helped me define my post-graduation goals. Learning about fascinating interdisciplinary research and meeting so many wonderful scientists solidified my desire to pursue both graduate school and higher level data science training.  Overall, it was an inspiring and educational week!
+
+-- Skylar Gering, Harvey Mudd College, USA, in-person participant
+```
+
+```{epigraph}
+ I have been interested in participating in a hackathon for a few years now, but as a marine biologist with no formal training in programming, I always felt I may not know enough to be able to make a meaningful contribution. But since OceanHackWeek focuses on ocean related issues, I finally decided to participate, and I am very glad I did. I found the organisers and fellow OHW 2021 participants were extremely welcoming and supportive, so my concerns about not being an expert coder soon vanished. I also really enjoyed participating with people from all over the world because they brought completely different perspectives, which meant we could solve problems a lot faster.... Overall, I found OHW 2021 to be a really positive experience through which I was able to participate with an incredibly diverse team and I am sure it will help me become a better coder and team player. I cannot wait for next year’s edition. [...] Thanks again for organising such an amazing event!
+
+-- Denisse Fierro Arcos, Institute for Marine and Antarctic Science, Australia, Oceania virtual event participant
+
+```
+
+```{epigraph}
+I went into OHW with a basic knowledge of Python and GitHub, and zero experience in collaborative coding. I had no intention to pitch a project and planned on joining another team… During the project pitching session, I felt encouraged by the inviting and friendly atmosphere and decided to mention a project that I have been trying to start for a few months - a complex coding project that I was stuck on and frustrated with. The OHW participants I interacted with were super encouraging and by the end of the day I was leading a team of five to develop a Python package! The rest of the week has been awesome: it was inspiring to learn from the team, all of whom brought different skills to the table and were eager to collaborate and contribute. The positive atmosphere created by the OHW organizers was contagious: everyone was supportive, kind, and encouraging. By the last day, we were proud to have made a working prototype of our package and showcase it to the group, and at least a few members of the team plan to  continue developing it going forward. This experience was excellent in every way - I learned a ton, met great people, and made unexpectedly huge progress on a project. Thank you for an amazing week! 
+
+-- Kyla Drushka, University of Washington, USA, main virtual event participant
+
+```
+
+## OHW20 (Virtual)
+
+```{epigraph}
+OceanHackWeek 2020 has been an inspiring event where I have learnt about open source ocean data and coding, and it has opened a wide window of possibilities for our lab daily tasks, being useful for research, outreach and even conservation. The workshop has provided a set of powerful tools for accessing and processing large public datasets, which is particularly useful in an ocean area where there is a lack of ocean observations. Besides, Github will be immediately applicable on coding collaboration within my lab. On top of that, OHW2020 was a bright light in Covid-19 times, bringing to my living room in Chile an amazing group of people, organizers and participants. I totally recommend OHW2021!
+
+-- Maria Valladares, Universidad Católica del Norte, Chile
+```
+
+```{epigraph}
+OceanHackWeek far exceeded my expectations last week when I attended the first virtual version of this workshop. I thought I would learn some tips and tricks for working with big data in Python and version control using git but I gained so much more. I am walking away with a wealth of knowledge on how to work with oceanographic data of all types and how to collaborate on code development to generate high quality code that is reproducible and open source. This workshop allows you to work side-by-side (virtually in this case) with experts on projects from start to finish so you can really learn and implement best practices. I am excited to share what I have learned with my colleagues and to collaborate more effectively in the future to create better data analysis tools and software. I also look forward to starting up our own hacking events!
+
+-- Lindsay Abrams, NOAA, USA
+```
+
+```{epigraph}
+Oceanhackweek was an incredible experience. Possibly the best oceanographic event I’ve attended and certainly the best organised. Oceanhackweek combined the expert lectures and tutorials of a summer school with the flat organisation, collaborative coding and peer learning of a hackathon. I learned so much from the organisers and participants. I learned more about coding and collaboration in a week of hacking than in a year of my PhD. It was great to see demos of all the awesome oceanoraphic tools and resources out there, often by the creators themselves. As big data becomes a reality on oceanography, and the reproducibility crisis looms, effective data processing is becoming more important than ever. Oceanhackweek is an excellent and much needed resource for the oceanographic community.
+ 
+I also enjoyed the community aspect of the hackathon. The organisers made a real effort to include participants, from suggesting additions to the code of conduct on Monday, through to presenting our hackathon projects at the end of the week. Perhaps most importantly for me, the organisers and participants of Oceanhackweek showed me how you can contribute to oceanography outside of tenure track academia. It was inspiring to see how I can combine my experience in oceanography and my love for free open source software into a viable career, not just a weekend hobby.
+
+(see also [Callum's Blog post about OHW20](https://callumrollo.github.io/hackweek.html))
+
+-- Callum Rollo, University of East Anglia, United Kingdon
+```
+
+```{epigraph}
+When I received the email saying that my application to Ocean Hack Week had been accepted I had no idea of what was to come. Being based in Australia my first concern was the time zone, and that I would be working from 1am to 6am in the morning. I considered pulling out and putting it in the too hard basket, but that inner voice kept on telling me that it would be worth the effort. So I set up the caravan on my driveway outside my house so that I could sleep during the day and not be woken up by my kids going to school. [...]
+ 
+The first night proved difficult and at times I stopped the video stream as my head was in my hands on the desk, but just seeing all those people on the zoom call got me through the night. Seeing how committed everyone was making the most of the time was quite overwhelming. The zoom breakout rooms were hives of activity with most people joining in and great discussions. Selecting a project and working on it took over my week, I dropped all my local work and focused on the project, and as normal what seemed a fairly simple project was way more complex than anticipated. By the time it came to the project show case we had just really got going and it was a real shame to stop, I think we will all re-start our project soon!
+ 
+Following along with tutorials was great and effective, but the best thing for me was the hacking, building a team and trying to achieve a goal, I learn so much about working in a team and how to engage with others. Looking back at what we achieved in the end and how we had bonded as a team was really heartening. I hope to make it back to the next Ocean Hack Week as a project mentor and perhaps develop a tutorial that can be used as part of OHW 2021.
+
+-- Nick Mortimer, CSIRO, Australia
+```
+
+## OHW19 (In person)
+
+```{epigraph}
+My experience at the Oceanhackweek 2019 was in a few words a once in a lifetime learning experience. The people involved were amazing, from the organization group to all the participants. The project group I joined was extremely democratic and involved. I learned not only from more advanced researchers but also telling what I knew to my group partners. I definitely recommend this event for everyone that is eager to learn.
+
+-- Ágata Piffer Braga, Universidade de São Paulo, Brazil
+```
+
+```{epigraph}
+I feel so lucky that I didn't miss the brainstorm of the data techniques in OHW2019. I have been using python for data analysis abut two years. [...] And I was quite satisfied with Python packages [...] which are extensively used in my data analysis for numerical model outputs. So when I heard about Oceanhackweek, I expected that probably I could meet more Python fellows in the ocean community, and it will be very beneficial to stay in a community for debugging and learn new staff in future works. Actually, the week spent in OHW2019 paid me much more than I could ever have expected. Packages, such as xarray and Dask, expanded my vision on python’s applications in ocean data analysis. Lectures on Github opened the door of so many repositories of open-source projects. Pangeo provided a cutting-edge platform for oceanographers to use packages specifically written for ocean data. Cloud data storage and cloud computation demonstrated great potential for ocean researches. And the project work during the workshop really makes our hands dirty in using the techniques we learned. Our team worked on quality control using machine-learning methods. It was a lot of cooperation, hardworking, fun, and friendships.
+
+-- Xu Chen, Florida State University, USA
+```
+
+## OHW18 (In person)
+
+```{epigraph}
+The workshop provided an excellent introduction to the existing infrastructure of oceanographic data-gathering resources. Also provided was an introduction to the open-source evolving tools for accessing and utilizing large data sets. The technical challenges in data-intensive research are daunting, and here this workshop’s model and enactment of collaborative work was particularly valuable to me.
+
+-- Rachel Jackson, San Francisco State University, USA
+```
+
+```{epigraph}
+I am grateful to have attended Oceanhackweek, and to have been given the opportunity to expand my skill set in such a productive and pleasant environment. I live in Fairbanks, AK, where we are rather isolated and aren't naturally exposed to new tools or methods. [...] Oceanhackweek gave me that time, introduced me to possibilities via the tutorials, and through the projects produced a technical structure that I can apply to our research in Alaska.
+
+-- Liz Dobbins, University of Alaska, Fairbanks, USA
+```
+
+```{epigraph}
+It is sometimes hard to predict whether a given conference, training or hack-a-thon might be worth your time. [...] The real challenge, of course, is to find a group of like minded people that want to expand their horizons and learn together, and that is just what I found when I attended Ocean Hackweek.
+
+-- Christian Saranson, USA
+```


### PR DESCRIPTION
Moved the 2018-19 testimonials from the Past OHW Events page to a new stand-alone Testimonials page, and added all 2020 testimonials and about half of the 2021 testimonials.

Added details about each OHW event to the Past OHW Events page