### PR TITLE
Overhaul tutorial getting started page; fix links and header anchor labels

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -128,6 +128,7 @@ post_date_format = "%d %B %Y"
 # -- Myst config ---------------------------------------------------
 myst_admonition_enable = True
 myst_deflist_enable = True
+myst_heading_anchors = 3
 myst_update_mathjax = False
 myst_enable_extensions = ["substitution", "colon_fence"]
 

--- a/ohw22/index.md
+++ b/ohw22/index.md
@@ -37,7 +37,7 @@ The [**Global Virtual Event**](global/index) will take place through synchronous
 ### Regional Satellites
 [**Six Regional Satellite Events**](satellites) will take place this year to serve as local connecting points for project work, community building, and engaging potential future OHW organizers. [OHW22 organizers](organizers) invite participants geographically located near one of these regional satellites or interested in virtual participation in a specific satellite to select one of these events. The satellite events may be virtual or in-person and take different formats depending on the event organizers. In-person participants may be required to be fully vaccinated against COVID-19.
 
-In coordination with the OHW Northwest satellite event, there will be a **[3-week-long undergraduate summer program “Data Science in Oceanography”](satellites/#undergraduate-summer-program-data-science-in-oceanography) taking place in-person on August 8-26 at the University of Washington**. This program will provide opportunities for undergraduate students in data-driven research in oceanography. See [the satellite event page](./seattle/index.md) for detail.
+In coordination with the OHW Northwest satellite event, there will be a **[3-week-long undergraduate summer program “Data Science in Oceanography”](seattle/index.md#undergraduate-summer-program-august-8-26-2022) taking place in-person on August 8-26 at the University of Washington**. This program will provide opportunities for undergraduate students in data-driven research in oceanography. See [the satellite event page](./seattle/index.md) for detail.
 
 ## OHW22 Sponsors
 

--- a/resources/logistics/getting_help.md
+++ b/resources/logistics/getting_help.md
@@ -42,5 +42,5 @@ See the [Projects Getting Started page](../projects/steps.md). Feel free to post
 
 ## Reporting a Code of Conduct violation
 
-Harassment and other [Code of Conduct violations](../conduct.md) reduce the value of OceanHackWeek for everyone. If someone makes you or anyone else feel unsafe or unwelcome, please report it as soon as possible to one of the instructors. You can make a report either personally or anonymously. **Anonymous reports can be made [here](https://oceanhackweek.wufoo.com/forms/zep2ybt1swlulc/).**
+Harassment and other [Code of Conduct violations](../../about/code-of-conduct.md) reduce the value of OceanHackWeek for everyone. If someone makes you or anyone else feel unsafe or unwelcome, please report it as soon as possible to one of the instructors. You can make a report either personally or anonymously. **Anonymous reports can be made [here](https://oceanhackweek.wufoo.com/forms/zep2ybt1swlulc/).**
 

--- a/resources/logistics/index.md
+++ b/resources/logistics/index.md
@@ -8,7 +8,7 @@ OceanHackWeek 2022 will take place August 15-19.
 
 **In-person participants** will gather as for times as directed by the satellite organizers. While **virtual participants** may choose to engage primarily with this group and schedule via Zoom and Slack, we strongly encourage you to join the program designed specifically as a virtual event. The virtual event will be split into two schedules and groups based on the distribution of participant time zones, in a 3-hour daily block of formal, live activities. The **larger virtual event** will take place 11:00am - 2:00pm PDT / 18:00 - 21:00 UTC.
 
-Detailed schedules are available [Schedule page](../schedule.md).
+Detailed schedules are available [Schedule page](../../ohw22/schedule.md).
 
 ## Channel of communication: Slack
 
@@ -27,7 +27,7 @@ We will use Zoom to broadcast all tutorials. The Zoom link will be distributed v
 
 ## Hack projects
 
-See [Project overview](../projects/overview.md) and [Hacking at OHW21](../projects/steps.md) for more info.
+See [Project overview](../projects/index.md) and [Hacking at OHW22](../projects/steps.md) for more info.
 
 ## Getting Help
 

--- a/resources/prep/git.md
+++ b/resources/prep/git.md
@@ -214,7 +214,7 @@ Submit a pull request by clicking `New pull request`:
 * Reviewer: look through changes in the files
 * Approve PR or ask for more changes.
 
-```{admonition}
+```{admonition} Note
 While your pull request is pending, any change you push to the fork will become a part of the request. This is useful if you are asked to make small changes before your PR is accepted.
 ```
 

--- a/resources/prep/github.md
+++ b/resources/prep/github.md
@@ -9,7 +9,7 @@ The resources are actively being updated! Some parts are still out of date, and 
 
 ## About Git and GitHub
 
-[Git](https://git-scm.com/) is a popular version control system that is the foundation of most open source software development. You are not required to be a Git pro in advance of this event, but come prepared to learn a lot about it! [GitHub](github.com) is a hosting service for Git repositories, enabling us to share code across teams in a web environment.
+[Git](https://git-scm.com/) is a popular version control system that is the foundation of most open source software development. You are not required to be a Git pro in advance of this event, but come prepared to learn a lot about it! [GitHub](https://github.com) is a hosting service for Git repositories, enabling us to share code across teams in a web environment.
 
 We will use Git and GitHub for collaborative work. Be sure to arrive at {OceanHackWeek with your own [GitHub](https://github.com/) account.
 

--- a/resources/prep/jupyterhub.md
+++ b/resources/prep/jupyterhub.md
@@ -42,7 +42,7 @@ It will take a bit of time for this to load - be patient! Once things are spun u
 
 ## How do I get the tutorial repository?
 
-For the tutorials, there are two primary ways of getting the notebooks. You can use the traditional git management route ([described below](#How-do-I-get-my-code-in-and-out-of-JupyterHub)), or you can use [this magical nbgitpuller link](https://oceanhackweek.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=lab%2Ftree%2Fohw-tutorials%2F&branch=master). 
+For the tutorials, there are two primary ways of getting the notebooks. You can use the traditional git management route ([described below](#how-do-i-get-my-code-in-and-out-of-jupyterhub)), or you can use [this magical nbgitpuller link](https://oceanhackweek.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=lab%2Ftree%2Fohw-tutorials%2F&branch=master). 
 
 Nbgitpuller is nice, because it will automatically merge any changes you make with the changes from the upstream repo on subsequent pulls via a [series of sane rules](https://jupyterhub.github.io/nbgitpuller/topic/automatic-merging.html#topic-automatic-merging).
 

--- a/resources/tutorials/getting_started.md
+++ b/resources/tutorials/getting_started.md
@@ -1,81 +1,15 @@
 # Getting started on tutorials
 
-:::{admonition} Updates in progress
-:class: warning
-
-The resources are actively being updated! Some parts are still out of date, and is the content from last year. In the meantime, please watch out for references to 2020, 2021 ("OHW21") or links that don't work.
-
-:::
-
 ## Introduction
 
-Most tutorials will be run live as Jupyter notebooks on the [OceanHackWeek JupyterHub ("The Hub")](https://ocean.hackweek.io/) in your browser. The instructor and and all participants can be running their own copies of the notebooks in their Hub account, with files cloned from the OHW source in GitHub.
+Tutorials will be run live on the [OceanHackWeek JupyterHub ("The Hub"), https://oceanhackweek.2i2c.cloud](https://oceanhackweek.2i2c.cloud) in your browser either as Jupyter notebooks or as scripts and notebooks in RStudio. The instructor and all participants can be running their own copies of the tutorial in their Hub account, with files cloned from the OHW source in GitHub.
 
-Below are instructions for getting the tutorials started on the the Hub in your browser, and updating the tutorials files with the latest version from GitHub. The schedule of tutorials is available [here](../schedule.md), and links to tutorial materials and some background resources are availabe elsewhere in the Tutorials section.
+Below are instructions for getting the tutorials started on the the Hub in your browser, and updating the tutorials files with the latest version from the GitHub tutorials repository, [https://github.com/oceanhackweek/ohw-tutorials](https://github.com/oceanhackweek/ohw-tutorials).
 
+The schedule of tutorials is available [here](../../ohw22/schedule.md), and links to tutorial materials and some background resources will be available there as well.
 
-## Pre-Hackweek tutorials
+## How do I get the tutorial repository into the Hub?
 
-- **Git and GitHub, including the Git fork - clone "workflow".** [Presentation slides (pdf)](https://github.com/oceanhackweek/ohw-preweek/tree/master/git-github-survival-guide") &mdash; [video](https://youtu.be/7nYFRixSV2c)
-- **Jupyter and Scientific Python basics: numpy, pandas, matplotlib.** [Jupyter notebooks](https://github.com/oceanhackweek/ohw-preweek/tree/master/data-analysis-modules) &mdash; [video](https://youtu.be/CTUAgpvfze0)
+For the tutorials, we recommend the use of [nbgitpuller](https://jupyterhub.github.io/nbgitpuller/) to clone and pull the tutorials repository, or update the clone you already have. Use [this magical nbgitpuller link](https://oceanhackweek.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=lab%2Ftree%2Fohw-tutorials%2F&branch=master) to accomplish this clone or update.
 
-
-## Start the Hub in your browser
-
-### Step 1
-Navigate to the [OceanHackWeek Hub, https://ocean.hackweek.io/](https://ocean.hackweek.io/).
-
-### Step 2
-Sign in using your GitHub account, if you are not already signed in. (First time only: Grant the OceanHackWeek Organization permissions - this grants you access to the cloud computing environment for the Hackweek.)
-
-### Step 3
-Start the "Oceanhackweek" computing environement (the Oceanhackweek "image"). It may take up to a minute or so to start up.
-
-
-## Upload (`git clone`) a copy of the `oh20-tutorials` GitHub repository and follow along
-This basic workflow allows you to follow along with tutorials with your own live copy of the tutorials notebooks while staying up-to-date with any changes made to the master tutorials repository, [ohw20-tutorials](https://github.com/oceanhackweek/ohw20-tutorials).
-
-### Shortcut
-The first time you try to upload (`git clone`) the `ohw20-tutorials` repository, launch a new terminal, then enter:
-
-```bash
-git clone https://github.com/oceanhackweek/ohw20-tutorials.git
-```
-
-Now you have a new `ohw20-tutorials` directory under your "home" directory, `/home/jovyan`. You're good to go!
-
-### Longer description - Step 1
-Navigate to the [tutorial repository on GitHub](https://github.com/oceanhackweek/ohw20-tutorials).
-
-Clone the tutorial to the Hub environment. You can easily copy the link to a repository by selecting the green "clone or download" dropdown (making sure the pop up says "Clone with HTTPS") and hitting the clipboard icon, which will automatically copy the link for you.
-
-Launch a terminal using the "plus" sign in the upper left corner of your JupyterHub:
-
-![Jupyter Launch Terminal](../img/Jupyter-LaunchNewTerminal.jpg)
-
-then execute the `git clone` statement:
-
-```bash
-git clone https://github.com/oceanhackweek/ohw20-tutorials.git
-```
-
-A new `ohw20-tutorials` directory will be created, holding the repository clone.
-
-<!-- _Note: a more detailed version of step 1, including images, is available as part of the [Preliminary Steps - JupyterHub Connection](https://icesat-2hackweek.github.io/learning-resources/preliminary/jupyterhub/#how-do-i-get-my-code-in-and-out-of-pangeo) -->
-
-### Step 2
-Follow along by opening and running the tutorial notebooks. You can save changes within your clone (such as edits to a notebook) or add other files, then download a copy to your local machine if you'd like.
-
-### Step 3
-Update your Hub copy with any changes to the `origin` repository. If you have saved changes within your local copy of the notebook or added other files, this may cause conflicts (*ask us questions if you run into problems!*). Fetch and merge (using `git pull`) the latest changes from the `origin` remote.
-
-```bash
-git pull origin
-```
-
-These instructions assume you're working on the default `master` branch.
-
-**Please note: the OceanHackWeek JupyterHub (the Hub) should not be relied upon to save your files beyond the duration of the hackweek, and will be removed a couple of weeks after the hackweek. Thus, for any non-repository changes or repository changes that have not been pushed to GitHub, you MUST complete Step 3 to save the files to your local machine if you would like continued access to them.**
-
-----
-Adapted from [https://icesat-2hackweek.github.io/learning-resources/tutorials/getting_started/](https://icesat-2hackweek.github.io/learning-resources/tutorials/getting_started/). Originally from [https://medium.com/sweetmeat/how-to-keep-a-downstream-git-repository-current-with-upstream-repository-changes-10b76fad6d97](https://medium.com/sweetmeat/how-to-keep-a-downstream-git-repository-current-with-upstream-repository-changes-10b76fad6d97)
+See this [extended discussion](../prep/jupyterhub.md#how-do-i-get-the-tutorial-repository) for more details about `nbgitpuller` and the alternative approach relying on `git` commands and `GitHub` workflows.


### PR DESCRIPTION
- Replaced `tutorials/getting_started.md` with updated content from corresponding ohw21 page. Basically, the content that was there was from [the ohw20 page](https://oceanhackweek.github.io/ohw-resources/ohw20/tutorials/getting_started/); I replaced it with [the ohw21 page](https://oceanhackweek.github.io/ohw-resources/tutorials/getting_started/) and made a few small updates.
- Enabled MyST auto-generated header anchor label slugs. The missing setting in `conf.py` was preventing the use of header-anchor links in the web site, both within the page and across pages (eg, #go-here, other-page.md#go-here)
- Fixed several internal and external broken links