### PR TITLE
Fix typos related to conda stuff

### DIFF
--- a/_InstructionSiteUpdates.md
+++ b/_InstructionSiteUpdates.md
@@ -57,7 +57,7 @@ It is worth noting that we are using the `source` branch as the base for this re
 #### Environment
 
 There is a pre-configured conda environment in `environment.yml`.
-To use it, `conda create env -f=./environment.yml`, then activate with `conda activate ohw-site`.
+To use it, `conda env create -f=./environment.yml`, then activate with `conda activate ohw-site`.
 
 #### Commands
 

--- a/resources/prep/conda.md
+++ b/resources/prep/conda.md
@@ -90,7 +90,7 @@ The [package](https://github.com/Anaconda-Platform/nb_conda_kernels) that detect
 
 ## Conda on your own computer
 
-Conda may be used on your computer as well as the Hub. If you wish to install the same environment as the hub is running, after you install Conda, you can download the [`environment.yml`](https://github.com/oceanhackweek/jupyter-image/blob/main/py-base/environment.yml) that we use, then `conda env create -n <ENV NAME> --file environment.yml`
+Conda may be used on your computer as well as the Hub. If you wish to install the same environment as the hub is running, after you install Conda, you can download the [`environment.yml`](https://github.com/oceanhackweek/ohw-tutorials/blob/OHW20/environment.yml) that we use, then `conda env create -n <ENV NAME> --file environment.yml`
 
 ### Installing Conda
 

--- a/resources/prep/conda.md
+++ b/resources/prep/conda.md
@@ -90,7 +90,7 @@ The [package](https://github.com/Anaconda-Platform/nb_conda_kernels) that detect
 
 ## Conda on your own computer
 
-Conda may be used on your computer as well as the Hub. If you wish to install the same environment as the hub is running, after you install Conda, you can download the [`environment.yml`](https://github.com/oceanhackweek/ohw20-tutorials/blob/master/environment.yml) that we use, then `conda create -n <ENV NAME> --file environment.yml`
+Conda may be used on your computer as well as the Hub. If you wish to install the same environment as the hub is running, after you install Conda, you can download the [`environment.yml`](https://github.com/oceanhackweek/jupyter-image/blob/main/py-base/environment.yml) that we use, then `conda env create -n <ENV NAME> --file environment.yml`
 
 ### Installing Conda
 

--- a/resources/prep/conda.md
+++ b/resources/prep/conda.md
@@ -90,7 +90,7 @@ The [package](https://github.com/Anaconda-Platform/nb_conda_kernels) that detect
 
 ## Conda on your own computer
 
-Conda may be used on your computer as well as the Hub. If you wish to install the same environment as the hub is running, after you install Conda, you can download the [`environment.yml`](https://github.com/oceanhackweek/ohw-tutorials/blob/OHW20/environment.yml) that we use, then `conda env create -n <ENV NAME> --file environment.yml`
+Conda may be used on your computer as well as the Hub. If you wish to install the same environment as the hub is running, after you install Conda, you can download the [`environment.yml`](https://raw.githubusercontent.com/oceanhackweek/ohw-tutorials/d51c880111305d7e345d98b7d8ccc031cbf0087e/environment.yml) that we use, then `conda env create -n <ENV NAME> --file environment.yml`
 
 ### Installing Conda
 


### PR DESCRIPTION
This fixes three minor typos related to conda instructions on the website, including the link to the conda environment file.