### PR TITLE
Add per-event links to participant testimonials

### DIFF
--- a/about/pasthackweeks.md
+++ b/about/pasthackweeks.md
@@ -36,7 +36,7 @@ OceanHackWeek started out as an in-person event in Seattle with limited virtual 
 - An in-person event with 54 participants at the University of Washington, Seattle, Washington
 - Programming languages: Python
 - 8 tutorials + [11 projects](https://oceanhackweek.github.io/ohw19/projects_2019.html)
-- [Participant testimonials](testimonials#ohw19-in-person)
+- [Participant testimonials](testimonials.md#ohw19-in-person)
 - [Schedule](https://oceanhackweek.github.io/ohw19/curriculum_2019.html). Links to tutorials are found here.
 - [Web site](https://oceanhackweek.github.io/ohw19/)
 

--- a/about/pasthackweeks.md
+++ b/about/pasthackweeks.md
@@ -11,38 +11,40 @@ OceanHackWeek (**OHW**) has taken place annually starting in 2018. Materials fro
 
 OceanHackWeek started out as an in-person event in Seattle with limited virtual access in 2018 and 2019, but moved to a virtual format in 2020 and a hybrid format in 2021.
 
-See [Testimonials](testimonials) for quotes from past participants.
-
 ## 2021 (OHW21)
 
 - A hybrid event with 70 participants, including 19 in-person participants at the Bigelow Laboratory for Ocean Sciences, East Boothbay, Maine
-- 7 tutorials + [11 projects](https://oceanhackweek.github.io/ohw-resources/projects/projectlist/)
 - Programming languages: Python + R
+- 7 tutorials + [11 projects](https://oceanhackweek.github.io/ohw-resources/projects/projectlist/)
+- [Schedule](https://oceanhackweek.github.io/ohw-resources/schedule/#main-virtual-event). Links to tutorials are found here.
+- [Participant testimonials](testimonials#ohw21-hybrid)
 - [Web site](https://oceanhackweek.github.io/ohw21/)
 - [OHW21 Resources site](https://oceanhackweek.github.io/ohw-resources/)
-- [Schedule](https://oceanhackweek.github.io/ohw-resources/schedule/#main-virtual-event). Links to tutorials are found here.
 
 ## 2020 (OHW20)
 
 - A virtual event with 46 participants
-- 10 tutorials + [8 projects](https://oceanhackweek.github.io/ohw21/projects_2020.html)
 - Programming languages: Python + R
+- 10 tutorials + [8 projects](https://oceanhackweek.github.io/ohw21/projects_2020.html)
+- [Participant testimonials](testimonials#ohw20-virtual)
+- [Schedule](https://oceanhackweek.github.io/ohw-resources/ohw20/schedule/). Links to tutorials are found here.
 - [Web site](https://oceanhackweek.github.io/ohw20/)
 - [OHW20 Resources site](https://oceanhackweek.github.io/ohw-resources/ohw20/)
-- [Schedule](https://oceanhackweek.github.io/ohw-resources/ohw20/schedule/). Links to tutorials are found here.
 
 ## 2019 (OHW19)
 
 - An in-person event with 54 participants at the University of Washington, Seattle, Washington
-- 8 tutorials + [11 projects](https://oceanhackweek.github.io/ohw19/projects_2019.html)
 - Programming languages: Python
-- [Web site](https://oceanhackweek.github.io/ohw19/)
+- 8 tutorials + [11 projects](https://oceanhackweek.github.io/ohw19/projects_2019.html)
+- [Participant testimonials](testimonials#ohw19-in-person)
 - [Schedule](https://oceanhackweek.github.io/ohw19/curriculum_2019.html). Links to tutorials are found here.
+- [Web site](https://oceanhackweek.github.io/ohw19/)
 
 ## 2018 (OHW18)
 
 - An in-person event with 52 participants at the University of Washington, Seattle, Washington
-- 13 tutorials + [11 projects](https://oceanhackweek.github.io/ohw2018/projects.html)
 - Programming languages: Python
-- [Web site](https://oceanhackweek.github.io/ohw2018/)
+- 13 tutorials + [11 projects](https://oceanhackweek.github.io/ohw2018/projects.html)
+- [Participant testimonials](testimonials#ohw18-in-person)
 - [Schedule](https://oceanhackweek.github.io/ohw2018/schedule.html). Links to tutorials are found here.
+- [Web site](https://oceanhackweek.github.io/ohw2018/)

--- a/about/pasthackweeks.md
+++ b/about/pasthackweeks.md
@@ -17,7 +17,7 @@ OceanHackWeek started out as an in-person event in Seattle with limited virtual 
 - Programming languages: Python + R
 - 7 tutorials + [11 projects](https://oceanhackweek.github.io/ohw-resources/projects/projectlist/)
 - [Schedule](https://oceanhackweek.github.io/ohw-resources/schedule/#main-virtual-event). Links to tutorials are found here.
-- [Participant testimonials](testimonials#ohw21-hybrid)
+- [Participant testimonials](testimonials.md#ohw21-hybrid)
 - [Web site](https://oceanhackweek.github.io/ohw21/)
 - [OHW21 Resources site](https://oceanhackweek.github.io/ohw-resources/)
 

--- a/about/pasthackweeks.md
+++ b/about/pasthackweeks.md
@@ -26,7 +26,7 @@ OceanHackWeek started out as an in-person event in Seattle with limited virtual 
 - A virtual event with 46 participants
 - Programming languages: Python + R
 - 10 tutorials + [8 projects](https://oceanhackweek.github.io/ohw21/projects_2020.html)
-- [Participant testimonials](testimonials#ohw20-virtual)
+- [Participant testimonials](testimonials.md#ohw20-virtual)
 - [Schedule](https://oceanhackweek.github.io/ohw-resources/ohw20/schedule/). Links to tutorials are found here.
 - [Web site](https://oceanhackweek.github.io/ohw20/)
 - [OHW20 Resources site](https://oceanhackweek.github.io/ohw-resources/ohw20/)

--- a/about/pasthackweeks.md
+++ b/about/pasthackweeks.md
@@ -45,6 +45,6 @@ OceanHackWeek started out as an in-person event in Seattle with limited virtual 
 - An in-person event with 52 participants at the University of Washington, Seattle, Washington
 - Programming languages: Python
 - 13 tutorials + [11 projects](https://oceanhackweek.github.io/ohw2018/projects.html)
-- [Participant testimonials](testimonials#ohw18-in-person)
+- [Participant testimonials](testimonials.md#ohw18-in-person)
 - [Schedule](https://oceanhackweek.github.io/ohw2018/schedule.html). Links to tutorials are found here.
 - [Web site](https://oceanhackweek.github.io/ohw2018/)


### PR DESCRIPTION
The addition of those links will make the Past Hackweeks page a bit more complete. I also rearranged the order of existing items a bit, mainly to have the link to tutorials (via the Schedule) next to the listing of the number of tutorials