### PR TITLE
Comment out some broken links in unused page

### DIFF
--- a/resources/projects/guidelines.md
+++ b/resources/projects/guidelines.md
@@ -49,9 +49,10 @@ Optional: links to manuscripts or technical documents for more in-depth analysis
 * Developing tutorials for using NASA data on the cloud.
 * Working on an efficient open source matchup tutorial for satellite orbital data and in situ point or trajectory data.
 * Developing an OSS algorithm development toolbox in Python to deal with a 400GB AMSR brightness temperature - in situ matchup database.
+<!-- 
 * [Argovis - a visualualization and API for accessing Argo data](https://argovis.colorado.edu/ng/home)
 * [OHW18 Projects](https://oceanhackweek.github.io/projects.html)
-
+-->
 
 
 ## Project Data Storage


### PR DESCRIPTION
Comment out a broken link identified in PR #209

This project guidelines page apparently hasn't been actively used in a couple of years. Maybe it could be deleted altogether, or re-examined for integration into the web site. In the meantime, I'm addressing a broken link to that the link checker in PR #209 won't be cluttered with this noise.