### PR TITLE
Update front page with OHW23 note

### DIFF
--- a/about/pasthackweeks.md
+++ b/about/pasthackweeks.md
@@ -9,7 +9,20 @@ description: Access materials from past hackweeks
 
 OceanHackWeek (**OHW**) has taken place annually starting in 2018. Materials from past hackweeks are available, though they may be incomplete, particularly for older events. Links to past tutorials and projects are also provided in most cases.
 
-OceanHackWeek started out as an in-person event in Seattle with limited virtual access in 2018 and 2019, but moved to a virtual format in 2020 and a hybrid format in 2021.
+OceanHackWeek started out as an in-person event in Seattle with limited virtual access in 2018 and 2019, but moved to a virtual format in 2020 and a hybrid format starting in 2021.
+
+## 2022 (OHW22)
+
+- A hybrid event with a global virtual event, several in-person "satellite" events, and satellites in Spanish and Portuguese.
+- Programming languages: Python + R
+- [Web site](https://oceanhackweek.org/ohw22/)
+- **Additional details will be added soon.**
+
+
+<!-- - A hybrid event with 70 participants, including 19 in-person participants at the Bigelow Laboratory for Ocean Sciences, East Boothbay, Maine
+- 7 tutorials + [11 projects](https://oceanhackweek.github.io/ohw-resources/projects/projectlist/)
+- [Schedule](https://oceanhackweek.github.io/ohw-resources/schedule/#main-virtual-event). Links to tutorials are found here.
+- [Participant testimonials](testimonials.md#ohw21-hybrid) -->
 
 ## 2021 (OHW21)
 

--- a/index.md
+++ b/index.md
@@ -6,18 +6,12 @@ description: OceanHackWeek home
 
 # OceanHackWeek (OHW)
 
-:::{admonition} Join us at OceanHackWeek 2022!
+:::{admonition} Stay tuned for information about OceanHackWeek 2023!
 :class: note
 
-OceanHackWeek 2022 will take place **August 15-19, 2022**. The workshop will take a hybrid form consisting of a global virtual event and a number of regional “satellite” events that are either in-person or virtual. **Applicants have been notified and participants should expect further communications**
+We are making plans for OceanHackWeek 2023. While there are many decisions to be made, it will likely take place in August 2023. Visit us again by March 2023 for updates! In the meantime, you can learn more about OceanHackWeek by browsing this web site, including [last year's event, OHW22](ohw22/index); and [contact us](about/contact) if you're interested in helping out.
 
 
-```{button-link} ohw22/
-:color: primary
-:expand:
-:tooltip: OHW22
-Go to OceanHackWeek 2022
-```
 <!-- https://getbootstrap.com/docs/4.0/components/buttons/ -->
 :::
 
@@ -144,7 +138,7 @@ Virtual event: We expect to hold formal sessions in at least two time zones, USA
 :hidden:
 
 about/index.md
-% about/pasthackweeks.md
+about/pasthackweeks.md
 OceanHackWeek 2022 <ohw22/index.md>
 % posts
 ```


### PR DESCRIPTION
- Replace front-page OHW22 admonition with one about OHW23
- Add "Past OHW Events" back to the top menu (we removed it at the start of OHW22, to reduce clutter when all the focus was on OHW22 navigation). Hopefully that makes it a tad easier for visitors to find and browse past events.
- Add OHW entry to "Past OHW Events", though it's only an initial entry. Ideally we'll add more details later, to make it more analogous (comparable) to entries from previous years