### PR TITLE
Roll out first set of OHW23 pages

### DIFF
--- a/_ext/team.yaml
+++ b/_ext/team.yaml
@@ -31,6 +31,7 @@ team:
       - OHW20 Organizer
       - OHW21 Organizer
       - OHW22 Organizer - Florianopolis
+      - OHW23 Organizer
 
   - name: Chelle Gentemann
     title: Senior Scientist
@@ -66,6 +67,7 @@ team:
       - OHW20 Organizer
       - OHW21 Organizer
       - OHW22 Organizer - Global
+      - OHW23 Organizer
 
   - name: Charley Haley
     title: Organizational & Social Strategist
@@ -87,6 +89,7 @@ team:
       - OHW20 Organizer
       - OHW21 Organizer - Maine
       - OHW22 Organizer - Maine
+      - OHW23 Organizer
 
   - name: Jane Koh
     title: Program Specialist
@@ -115,6 +118,7 @@ team:
       - OHW20 Organizer
       - OHW21 Organizer
       - OHW22 Organizer - Seattle
+      - OHW23 Organizer
 
   - name: Paige Martin
     title: Support Scientist
@@ -146,6 +150,7 @@ team:
       - OHW21 Organizer
       - OHW22 Organizer - Seattle
       - OHW22 Organizer - Espanol
+      - OHW23 Organizer
 
   - name: Catherine Mitchell
     title: Senior Research Scientist
@@ -162,6 +167,7 @@ team:
       - OHW20 Organizer
       - OHW21 Organizer - Maine
       - OHW22 Organizer - Maine
+      - OHW23 Organizer
 
   - name: Thomas Moore
     title: Ocean Data Analyst
@@ -194,6 +200,7 @@ team:
       - Tutorials
       - OHW21 Organizer
       - OHW22 Organizer - Seattle
+      - OHW23 Organizer
 
   - name: Nick Mortimer
     title: Senior Engineer
@@ -206,6 +213,7 @@ team:
       - OHW20 Participant
       - OHW21 Organizer - Australia
       - OHW22 Organizer - Australia
+      - OHW23 Organizer
 
   - name: Sophie Clayton
     title: Assistant Professor of Oceanography
@@ -217,6 +225,7 @@ team:
       - Projects
       - OHW20 Organizer
       - OHW22 Organizer - Global
+      - OHW23 Organizer
 
   - name: Georgy Manucharyan
     title: Assistant Professor
@@ -239,6 +248,7 @@ team:
       - Financial Planning
       - OHW21 Participant
       - OHW22 Organizer - San Diego
+      - OHW23 Organizer
 
   - name: David Correa Chilón
     title: Specialist, Ocean-Atmosphere Interactions
@@ -260,6 +270,7 @@ team:
       - Tutorials
       - OHW21 Participant
       - OHW22 Organizer - Espanol
+      - OHW23 Organizer
 
   - name: Ángel Segura
     title: Adjunct Professor

--- a/about/pasthackweeks.md
+++ b/about/pasthackweeks.md
@@ -15,7 +15,7 @@ OceanHackWeek started out as an in-person event in Seattle with limited virtual 
 
 - A hybrid event with a global virtual event, several in-person "satellite" events, and satellites in Spanish and Portuguese.
 - Programming languages: Python + R
-- [Web site](https://oceanhackweek.org/ohw22/)
+- [Web site](../ohw22/index)
 - **Additional details will be added soon.**
 
 

--- a/index.md
+++ b/index.md
@@ -9,8 +9,8 @@ description: OceanHackWeek home
 ```{admonition} OceanHackWeek 2023 will be on August 7 - 11!
 :class: important
 
-We are making plans for OceanHackWeek 2023. It will be a hybrid event with an in-person gathering at the University of Washington in Seattle; a larger, global virtual event; and maybe a small Australian gathering. We will roll out initial web pages for OceanHackWeek 2023 very soon. 
-In the meantime, you can learn more about OceanHackWeek by browsing this web site, including [last year's event, OHW22](ohw22/index); and [contact us](about/contact) if you're interested in helping out.
+We are making plans for OceanHackWeek 2023. It will be a hybrid event with an in-person gathering at the University of Washington in Seattle; a larger, global virtual event; and maybe a small Australian gathering. Visit the [OHW23 event web site](ohw23/index) for more information,
+including updates about when applications will open!
 ```
 
 ```{admonition} OceanHackWeek en Español / in Spanish, Feb 27 - Mar 3, 2023!

--- a/index.md
+++ b/index.md
@@ -9,7 +9,7 @@ description: OceanHackWeek home
 ```{admonition} OceanHackWeek 2023 will be on August 7 - 11!
 :class: important
 
-We are making plans for OceanHackWeek 2023. It will be a hybrid event with an in-person gathering at the University of Washington in Seattle; a larger, global virtual event; and maybe a small Australian gathering. Visit the [OHW23 event web site](ohw23/index) for more information,
+OceanHackWeek 2023 will be a hybrid event with an in-person gathering at the University of Washington in Seattle; a larger, global virtual event; and maybe a small Australian gathering. Visit the [OHW23 event web site](ohw23/index) for more information,
 including updates about when applications will open!
 ```
 

--- a/index.md
+++ b/index.md
@@ -158,6 +158,6 @@ Virtual event: We expect to hold formal sessions in at least two time zones, USA
 
 about/index.md
 about/pasthackweeks.md
-OceanHackWeek 2022 <ohw22/index.md>
+OceanHackWeek 2023 <ohw23/index.md>
 % posts
 ```

--- a/ohw23/applicants.md
+++ b/ohw23/applicants.md
@@ -1,44 +1,32 @@
 ---
 layout: applicant
 # title: Information for Applicants
-description: OceanHackWeek (OHW) 2022
+description: OceanHackWeek (OHW) 2023
 permalink: applicant-info.html
 ---
 
 # Information for OHW23 Applicants
 
-OceanHackWeek 2023 (OHW23) is a hands-on, interactive workshop focused on data science in oceanography and fisheries. It will take place on **August 7-11, 2023** as a hybrid event with an in-person gathering at the University of Washington in Seattle; a larger, global virtual event; and possibly a small Australian gathering. Join us for five days of tutorials, data exploration, software development and community networking!
+OceanHackWeek 2023 is a hands-on, interactive hybrid in-person and virtual workshop focused on data science in oceanography and fisheries that will be held on **August 7-11, 2023**. Join us for five days of tutorials, data exploration, software development and community networking!
 
-OceanHackWeek 2021 is a small, hands-on, interactive hybrid in-person and virtual workshop focused on data science and oceanography that will be held during August 3-6, 2021. Join us for four days of tutorials, data exploration, software development and community networking!
-
-OceanHackWeek 2022 will happen from August 15-19, 2022. The workshop will take a hybrid form consisting of a global virtual event and a number of regional satellite events that are either in-person or virtual.
-
-
-
-The OceanHackWeek program consists of hands-on tutorials, visual presentations, and collaborative hack projects throughout a 5-day period. Participants can apply for being in one of the regional satellites or the global virtual event. Regional satellite events are connected closely with the global virtual event, while providing additional collaboration and networking opportunities on a regional basis.
-
-```{admonition} Applications have closed and participant selection is in progress
+```{admonition} Applications will open around May 8, 2023
 :class: important
 
-Accepted applicants will be notified no later than June 18, 2022.
+Please come back in early May for updates. **We plan to open applications
+starting around May 8, 2023.**
 ```
 
-The **in-person** event will take place at the University of Washington, in Seattle, Washington (US PDT, UTC-7), as an all-day workshop (approximately 9am - 5pm). We expect to accommodate approximately 20-25 participants.
+The **in-person** event will take place at the [University of Washington](http://www.washington.edu), in Seattle, Washington (US PDT, UTC-7), as an all-day workshop (approximately 9am - 5pm). We expect to accommodate approximately 20-25 participants.
 
 For the **virtual event**, formal daily activities will take place over a period of up to 3 hours per day. These activities include recorded tutorials with interactive discussions and project check-in with the entire group, but exclude actual project time. While plans are still tentative, we expect to hold these sessions in at least two time zones, USA EDT (UTC-4) and Australian EST (UTC+10).
 
 Please see the FAQs below for answers to common questions.
 For additional questions, please post in our [discussions on Github](https://github.com/orgs/oceanhackweek/discussions/categories/q-a) or email 
 <a href="mailto:info@oceanhackweek.org" target="_blank">info@oceanhackweek.org</a>.
-For satellite event-specific questions, please post in the discussions, or contact satellite organizers listed in the individual event pages.
 
 ---
 
 ## FAQs
-
-### Q: The satellite event in my region doesn't have a lot of details yet, what should I do?
-
-Some regional satellite organizers are still fleshing out details of the event, including the exact location. Feel free to ask in [Github Discussions](https://github.com/orgs/oceanhackweek/discussions/categories/q-a) or email them if there is specific information you need from them for you to make decisions on your application.
 
 ### Q: I am an undergrad / first year grad / faculty / etc. Is this program right for me?
 
@@ -57,10 +45,6 @@ If in doubt,
 simply apply and explain your motivation for participation.
 
 We expect all participants to be engaged in the team projects and focus during the week.
-
-### Q: I am an undergraduate, and I'm not sure I'm ready for this
-
-This year (2022) we have a special, enriched program for undergraduates! The "Data Science in Oceanography" program at the University of Washington (Seattle, WA) will provide opportunities for undergraduate students in data-driven research in oceanography. Participating students will interact closely with faculty and graduate student mentors to develop and advance individual research projects. Students will fully participate in the OHW Northwest satellite event as part of this 3-week long undergraduate program, with the regular OHW activities in the second week. See [here for details](seattle/index).
 
 ### Q: I am proficient in Matlab / other languages but have not used Python or R. Python or R has been on my list to learn. How can I make my application be stronger?
 
@@ -112,6 +96,7 @@ we require that participants have had at least some familiarity or prior experie
 ### Q: I work in an ocean engineering / robotics / consulting company. Can I apply?
 
 <!-- We expect participants from the private sector to pay for their own expenses. -->
+Yes, we welcome applications from the private sector. 
 Make sure to explain your motivation for participation in the application form!
 We may hold a career panel discussion,
 so please mention if you are interested in participating.

--- a/ohw23/applicants.md
+++ b/ohw23/applicants.md
@@ -18,7 +18,7 @@ starting around May 8, 2023.**
 
 The **in-person** event will take place at the [University of Washington](http://www.washington.edu), in Seattle, Washington (US PDT, UTC-7), as an all-day workshop (approximately 9am - 5pm). We expect to accommodate approximately 20-25 participants.
 
-For the **virtual event**, formal daily activities will take place over a period of up to 3 hours per day. These activities include recorded tutorials with interactive discussions and project check-in with the entire group, but exclude actual project time. While plans are still tentative, we expect to hold these sessions in at least two time zones, USA EDT (UTC-4) and Australian EST (UTC+10).
+For the **virtual event**, formal daily activities will take place over a period of up to 3 hours per day. These activities include recorded tutorials with interactive discussions and project check-in with the entire group, but exclude actual project time. While plans are still tentative, we expect to hold these sessions in at least two time zones, likely USA PDT (UTC-7) and Australian EST (UTC+10).
 
 Please see the FAQs below for answers to common questions.
 For additional questions, please post in our [discussions on Github](https://github.com/orgs/oceanhackweek/discussions/categories/q-a) or email 
@@ -103,14 +103,13 @@ so please mention if you are interested in participating.
 
 ### Q: I work in a non-US institution / organization / company. Can I apply?
 
-Yes, we welcome applications from abroad for the *virtual* event. 
-Due to COVID-19 concerns, the *in-person* event will be limited to vaccinated US residents.
+Yes, we welcome applications from abroad for both the in-person and virtual events.
 
 ### Q: I was a participant in previous OceanHackWeek. Can I apply again?
 
 Yes, we welcome applications from previous participants,
 but priority will be given to new applicants.
-If you are interested in being a TA (teaching assistant) during the hackweek,
+If you are interested in assisting as a project or tutorial helper during the hackweek,
 please mention that in the application.
 
 ### Q: Am I supposed to participate in all tutorials and presentations?

--- a/ohw23/applicants.md
+++ b/ohw23/applicants.md
@@ -1,0 +1,143 @@
+---
+layout: applicant
+# title: Information for Applicants
+description: OceanHackWeek (OHW) 2022
+permalink: applicant-info.html
+---
+
+# Information for OHW23 Applicants
+
+OceanHackWeek 2023 (OHW23) is a hands-on, interactive workshop focused on data science in oceanography and fisheries. It will take place on **August 7-11, 2023** as a hybrid event with an in-person gathering at the University of Washington in Seattle; a larger, global virtual event; and possibly a small Australian gathering. Join us for five days of tutorials, data exploration, software development and community networking!
+
+OceanHackWeek 2021 is a small, hands-on, interactive hybrid in-person and virtual workshop focused on data science and oceanography that will be held during August 3-6, 2021. Join us for four days of tutorials, data exploration, software development and community networking!
+
+OceanHackWeek 2022 will happen from August 15-19, 2022. The workshop will take a hybrid form consisting of a global virtual event and a number of regional satellite events that are either in-person or virtual.
+
+
+
+The OceanHackWeek program consists of hands-on tutorials, visual presentations, and collaborative hack projects throughout a 5-day period. Participants can apply for being in one of the regional satellites or the global virtual event. Regional satellite events are connected closely with the global virtual event, while providing additional collaboration and networking opportunities on a regional basis.
+
+```{admonition} Applications have closed and participant selection is in progress
+:class: important
+
+Accepted applicants will be notified no later than June 18, 2022.
+```
+
+The **in-person** event will take place at the University of Washington, in Seattle, Washington (US PDT, UTC-7), as an all-day workshop (approximately 9am - 5pm). We expect to accommodate approximately 20-25 participants.
+
+For the **virtual event**, formal daily activities will take place over a period of up to 3 hours per day. These activities include recorded tutorials with interactive discussions and project check-in with the entire group, but exclude actual project time. While plans are still tentative, we expect to hold these sessions in at least two time zones, USA EDT (UTC-4) and Australian EST (UTC+10).
+
+Please see the FAQs below for answers to common questions.
+For additional questions, please post in our [discussions on Github](https://github.com/orgs/oceanhackweek/discussions/categories/q-a) or email 
+<a href="mailto:info@oceanhackweek.org" target="_blank">info@oceanhackweek.org</a>.
+For satellite event-specific questions, please post in the discussions, or contact satellite organizers listed in the individual event pages.
+
+---
+
+## FAQs
+
+### Q: The satellite event in my region doesn't have a lot of details yet, what should I do?
+
+Some regional satellite organizers are still fleshing out details of the event, including the exact location. Feel free to ask in [Github Discussions](https://github.com/orgs/oceanhackweek/discussions/categories/q-a) or email them if there is specific information you need from them for you to make decisions on your application.
+
+### Q: I am an undergrad / first year grad / faculty / etc. Is this program right for me?
+
+We welcome participants from all career stages and encourage applications from graduate students,
+postdocs and early career researchers. Advanced undergrad students with background in oceanography
+and data science are also welcome.
+
+Before applying consider what you can bring to the event:
+by pitching a project,
+by your knowledge of data sets,
+by your programming/computational skills,
+by your project management skills.
+
+We want you to grow/learn during the event!
+If in doubt,
+simply apply and explain your motivation for participation.
+
+We expect all participants to be engaged in the team projects and focus during the week.
+
+### Q: I am an undergraduate, and I'm not sure I'm ready for this
+
+This year (2022) we have a special, enriched program for undergraduates! The "Data Science in Oceanography" program at the University of Washington (Seattle, WA) will provide opportunities for undergraduate students in data-driven research in oceanography. Participating students will interact closely with faculty and graduate student mentors to develop and advance individual research projects. Students will fully participate in the OHW Northwest satellite event as part of this 3-week long undergraduate program, with the regular OHW activities in the second week. See [here for details](seattle/index).
+
+### Q: I am proficient in Matlab / other languages but have not used Python or R. Python or R has been on my list to learn. How can I make my application be stronger?
+
+We plan to accept participants with diverse skill levels and backgrounds in programming.
+
+However, to best benefit from and contribute to the program, participants are expected to have some experience with Python and/or R programming.
+
+Applicants with an extensive programming background in other languages (e.g. Matlab) are welcome to apply,
+if they are willing to get up-to-date on the expected basic skills before the program.
+
+Participants should familiarize themselves with the materials included in [Python novice gapminder](https://swcarpentry.github.io/python-novice-gapminder/) and [Python novice inflammation](https://swcarpentry.github.io/python-novice-inflammation/) for a Python focus, or [R novice gapminder](http://swcarpentry.github.io/r-novice-gapminder/) for an R focus. These are a good reflection of the level we expect participants to be at coming into the workshop.
+
+### Q: I don't know the first thing about version revision/control systems. Can I still apply?
+
+During the hackweek we will use Git and GitHub but you are not expected to be an expert on it. In previous years we have offered refresher in the week prior to the actual OHW event. The organizing committee is deciding whether we can offer this in OHW22. You are welcome to check back here for this info, but we want to emphasize that nothing is better than trying it yourself first -- we recommend the [Software Carpentry lessons](https://swcarpentry.github.io/git-novice/) for learning git basic. 
+
+Note that we will require you to create a [GitHub account](https://github.com/) before completing the application.
+
+### Q: I do not have any programming experience. Is the program a good opportunity to get started?
+
+We believe that OceanHackWeek participants will benefit the most with some prior programming experience,
+and might not find the hackweek the best place to learn programming.
+
+If you do not have any programming experience we encourage you to start with some local or online training.
+Check if your institution runs a [Software Carpentry workshop](https://software-carpentry.org/workshops/).
+
+Once you have gone through some training you will have a better understanding of whether OceanHackWeek is right for you.
+We expect that you have basic operational knowledge of Python or R in advance of the program.
+
+### Q: Do I have to be a stellar Python or R programmer to be accepted?
+
+No. We aim to bring in motivated participants with a diverse range of programming skill levels.
+
+### Q: I already know a lot of what you plan to cover, should I apply / will I be bored?
+
+OceanHackWeek is not only a place to learn new skills but also a place to share expertise and build a community together.
+If you are already an expert but are interested in sharing and helping others,
+we welcome you to pitch project ideas,
+contribute to hacking,
+and assist other participants during the tutorials by being a teaching assistant!
+
+*Please mention this in the application. Send us an email if you have any questions!*
+
+### Q: I have strong computational skills but have not worked in oceanography?
+
+To ensure that participants will be interested in the oceanography problems they are solving and can give back to the field later on,
+we require that participants have had at least some familiarity or prior experience with oceanography data.
+
+### Q: I work in an ocean engineering / robotics / consulting company. Can I apply?
+
+<!-- We expect participants from the private sector to pay for their own expenses. -->
+Make sure to explain your motivation for participation in the application form!
+We may hold a career panel discussion,
+so please mention if you are interested in participating.
+
+### Q: I work in a non-US institution / organization / company. Can I apply?
+
+Yes, we welcome applications from abroad for the *virtual* event. 
+Due to COVID-19 concerns, the *in-person* event will be limited to vaccinated US residents.
+
+### Q: I was a participant in previous OceanHackWeek. Can I apply again?
+
+Yes, we welcome applications from previous participants,
+but priority will be given to new applicants.
+If you are interested in being a TA (teaching assistant) during the hackweek,
+please mention that in the application.
+
+### Q: Am I supposed to participate in all tutorials and presentations?
+
+Yes. While we understand that not all topics may be 100% relevant to you we want to maximize engagement. Note that we post the lessons and videos online later, so if you are interested in only a portion of the OceanHackWeek consider that an option rather than taking someone's spot.
+
+### Q: My application was not accepted, what now?
+
+Sadly resources are limited and we cannot accommodate all the applicants we would like.
+
+It is important to note that a rejected application does not mean a bad one! The reasons are:
+
+- The organizer tries to accommodate a good balance from novices to experts. That means a candidate may be rejected one year and accepted in another due to the different pool of applicants. Rule of thumb? Always apply again next year if possible! Also, if you believe you can contribute to the OHW as a helper instead of a student, please get in touch! We are always in need of helpers.
+- Another important factor that goes into the selection of candidates is the motivation paragraph in your application. Boilerplate answers or short answers like: "I want to participate" or "It is important to me" may get lower ranking than those who read the past year materials and wrote a paragraph on how the OHW can really make a difference to them. In short: be informed, be honest, be you!
+- Also, please refer to the FAQ question: "I am proficient in Matlab / other languages but have not used Python or R. It has been on my list to learn. How can I make my application be stronger?"

--- a/ohw23/index.md
+++ b/ohw23/index.md
@@ -1,6 +1,7 @@
 # OceanHackWeek 2023 (OHW23)
 
-OceanHackWeek 2023 (OHW23) is a hands-on, interactive workshop focused on data science in oceanography and fisheries. It will take place on **August 7-11, 2023** as a hybrid in-person and virtual, online event. The in-person event will take place at the [University of Washington](http://www.washington.edu), in Seattle, Washington (US PDT, UTC-7), as an all-day workshop (approximately 9am - 5pm). For the virtual event, formal daily activities will take place over a period of up to 3 hours per day. We expect to hold these sessions in at least two time zones, USA EDT (UTC-4) and probably Australian EST (UTC+10). 
+OceanHackWeek 2023 (OHW23) will be held on **August 7-11, 2023** as a hybrid in-person and virtual, online event. The in-person event will take place at the [University of Washington](http://www.washington.edu), in Seattle, Washington (US PDT, UTC-7), as an all-day workshop (approximately 9am - 5pm). For the virtual event, formal daily activities will take place over a period of up to 3 hours per day. 
+We expect to hold these sessions in at least two time zones, likely USA PDT (UTC-7) and Australian EST (UTC+10). 
 
 ```{image} ../assets/images/ohw_hacking/ohw19-hacking.JPG
 :alt: OHW19 in person, hacking
@@ -12,6 +13,12 @@ Join us for five days of hands-on tutorials, data exploration, software developm
 
 See the [OHW21 program](https://oceanhackweek.org/ohw-resources) (a hybrid event) to get a better sense of the usual activities and how they're organized.
 
+```{admonition} Applications will open around May 8, 2023
+:class: important
+
+Please come back in early May for updates. **We plan to open applications
+starting around May 8, 2023.** See the [Information for Applicants page](./applicants).
+```
 
 <!---
 :::{admonition} Join us at OceanHackWeek 2022!
@@ -33,7 +40,7 @@ In-person and virtual participants will have access to the same online resources
 :width: 220px
 :align: right
 ```
-The virtual event will take place through synchronous 3-hour periods per day and asynchronous collaboration. It will include all interactive OHW23 tutorials delivered in real time, project brainstorming, and other OHW-wide community building activities. The tutorials will be recorded and posted after the presentation. The exact hours of this global event are still being finalized, but we anticipate the activity time to be structured around the US Pacific Time (UTC-7) this year.
+The virtual event will take place through synchronous 3-hour periods per day and asynchronous collaboration. It will include all interactive OHW23 tutorials delivered in real time, project brainstorming, and other OHW-wide community building activities. Tutorials will be recorded and posted after the presentation.
 
 
 ## OHW23 Sponsors

--- a/ohw23/index.md
+++ b/ohw23/index.md
@@ -10,7 +10,7 @@ OceanHackWeek 2023 (OHW23) is a hands-on, interactive workshop focused on data s
 
 Join us for five days of hands-on tutorials, data exploration, software development, presentations, collaborative hack projects and community networking!
 
-See the [OHW21 program](https://oceanhackweek.github.io/ohw-resources) (a hybrid event) to get a better sense of the usual activities and how they're organized.
+See the [OHW21 program](https://oceanhackweek.org/ohw-resources) (a hybrid event) to get a better sense of the usual activities and how they're organized.
 
 
 <!---
@@ -24,21 +24,19 @@ Find password on Slack channel #ohw22_general!
 :::
  -->
 
-## A Global Virtual Event and Six Regional Satellites
+## A hybrid in-person and virtual event
 
-Global and satellite participants will have access to the same online resources and common communication channels, and will be encouraged to engage with one another.
-
-### Global Virtual Event
+In-person and virtual participants will have access to the same online resources and common communication channels, and will be encouraged to engage with one another.
 
 ```{image} ../assets/images/ohw_hacking/ohw21-slack.png
 :alt: OHW21 Slack exchanges
 :width: 220px
 :align: right
 ```
-The [**Global Virtual Event**](global/index) will take place through synchronous 3-hour periods per day and asynchronous collaboration. It will include all interactive OHW22 tutorials delivered in real time, project brainstorming, and other OHW-wide community building activities. The tutorials will be recorded and posted after the presentation. The exact hours of this global event are still being finalized, but we anticipate the activity time to be structured around the US Pacific Time (UTC-7) this year.
+The virtual event will take place through synchronous 3-hour periods per day and asynchronous collaboration. It will include all interactive OHW23 tutorials delivered in real time, project brainstorming, and other OHW-wide community building activities. The tutorials will be recorded and posted after the presentation. The exact hours of this global event are still being finalized, but we anticipate the activity time to be structured around the US Pacific Time (UTC-7) this year.
 
 
-## OHW22 Sponsors
+## OHW23 Sponsors
 
 <div class="row">
   <div class="col-4" style="margin-bottom: 1rem">

--- a/ohw23/index.md
+++ b/ohw23/index.md
@@ -1,0 +1,107 @@
+# OceanHackWeek 2023 (OHW23)
+
+OceanHackWeek 2023 (OHW23) is a hands-on, interactive workshop focused on data science in oceanography and fisheries. It will take place on **August 7-11, 2023** as a hybrid in-person and virtual, online event. The in-person event will take place at the [University of Washington](http://www.washington.edu), in Seattle, Washington (US PDT, UTC-7), as an all-day workshop (approximately 9am - 5pm). For the virtual event, formal daily activities will take place over a period of up to 3 hours per day. We expect to hold these sessions in at least two time zones, USA EDT (UTC-4) and probably Australian EST (UTC+10). 
+
+```{image} ../assets/images/ohw_hacking/ohw19-hacking.JPG
+:alt: OHW19 in person, hacking
+:width: 230px
+:align: left
+```
+
+Join us for five days of hands-on tutorials, data exploration, software development, presentations, collaborative hack projects and community networking!
+
+See the [OHW21 program](https://oceanhackweek.github.io/ohw-resources) (a hybrid event) to get a better sense of the usual activities and how they're organized.
+
+
+<!---
+:::{admonition} Join us at OceanHackWeek 2022!
+:class: note
+
+**Applicants have been notified and participants should expect further communications**
+GVE tutorials will be delivered on [Zoom](https://bigelow.zoom.us/j/84201880574).
+Find password on Slack channel #ohw22_general!
+
+:::
+ -->
+
+## A Global Virtual Event and Six Regional Satellites
+
+Global and satellite participants will have access to the same online resources and common communication channels, and will be encouraged to engage with one another.
+
+### Global Virtual Event
+
+```{image} ../assets/images/ohw_hacking/ohw21-slack.png
+:alt: OHW21 Slack exchanges
+:width: 220px
+:align: right
+```
+The [**Global Virtual Event**](global/index) will take place through synchronous 3-hour periods per day and asynchronous collaboration. It will include all interactive OHW22 tutorials delivered in real time, project brainstorming, and other OHW-wide community building activities. The tutorials will be recorded and posted after the presentation. The exact hours of this global event are still being finalized, but we anticipate the activity time to be structured around the US Pacific Time (UTC-7) this year.
+
+
+## OHW22 Sponsors
+
+<div class="row">
+  <div class="col-4" style="margin-bottom: 1rem">
+
+```{image} ../assets/images/eScience_square_logo.jpg
+:alt: UW eScience
+:width: 150px
+```
+
+  </div>
+  <div class="col-4" style="margin-bottom: 1rem">
+
+```{image} ../assets/images/BigelowLabs.png
+:alt: Bigelow Lab
+:width: 180px
+```
+
+  </div>
+  <div class="col-4" style="margin-bottom: 1rem">
+
+```{image} ../assets/images/apl_logo_blue.jpg
+:alt: UW APL
+:width: 180px
+```
+
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-4" style="margin-bottom: 1rem">
+
+```{image} ../assets/images/nsf.jpeg
+:alt: NSF
+:width: 150px
+```
+
+  </div>
+  <div class="col-4" style="margin-bottom: 1rem">
+
+```{image} ../assets/images/ioos_logo.jpg
+:alt: IOOS
+:width: 180px
+```
+
+  </div>
+  <div class="col-4" style="margin-bottom: 1rem">
+
+```{image} ../assets/images/logos/nasa-logo.sm.png
+:alt: NASA
+:width: 150px
+```
+
+  </div>
+
+</div>
+
+
+
+```{toctree}
+:maxdepth: 3
+:caption: OceanHackWeek 2023 (OHW23)
+:hidden:
+
+Organizers <organizers>
+Information for Applicants <applicants>
+```

--- a/ohw23/organizers.md
+++ b/ohw23/organizers.md
@@ -1,0 +1,12 @@
+---
+layout: page
+description: Team of OceanHackWeek 2022 organizers
+---
+
+# OceanHackWeek 2023 Organizers
+
+```{ohw-team}
+:roles: "OHW23 Organizer*"
+:badges:
+:hide_role_badges: "OHW18 O*,OHW19 O*,OHW20 O*,OHW21 O*,OHW22 O*,*Participant*,Steering *,Tutorials,Infrastructure,Applicant Selection,Projects,Financial Planning,Website"
+```


### PR DESCRIPTION
First batch of changes for OHW23 pages deployment.
- Created new OHW23 directory and minimal set of pages: main page, organizers and information for participants. Updated these pages.
- Added OHW23 Organizer role to team yaml file, but only for team members already present in the file
- Updated admonition on front page, to point to new OHW23 main page
- Changed top menu entries to demote OHW22 and promote OHW23
