### PR TITLE
Update web site for the opening of ohw23 applications

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,12 +6,21 @@ description: OceanHackWeek home
 
 # OceanHackWeek (OHW)
 
-```{admonition} OceanHackWeek 2023 will be on August 7 - 11!
+:::{admonition} OceanHackWeek 2023 will be on August 7 - 11!
 :class: important
 
-OceanHackWeek 2023 will be a hybrid event with an in-person gathering at the University of Washington in Seattle; a larger, global virtual event; and maybe a small Australian gathering. Visit the [OHW23 event web site](ohw23/index) for more information,
-including updates about when applications will open!
+**Applications for OceanHackWeek 2023 are now open!**  
+OceanHackWeek 2023 will be a hybrid event with a global virtual event; a smaller in-person gathering at the University of Washington in Seattle; and a small Australian gathering.
+
+```{button-link} ohw23/
+:color: primary
+:expand:
+:tooltip: OHW23
+Go to OceanHackWeek 2023
 ```
+<!-- https://getbootstrap.com/docs/4.0/components/buttons/ -->
+:::
+
 
 ```{admonition} OceanHackWeek en Español / in Spanish, Feb 27 - Mar 3, 2023!
 :class: note

--- a/ohw23/applicants.md
+++ b/ohw23/applicants.md
@@ -9,11 +9,12 @@ permalink: applicant-info.html
 
 OceanHackWeek 2023 is a hands-on, interactive hybrid in-person and virtual workshop focused on data science in oceanography and fisheries that will be held on **August 7-11, 2023**. Join us for five days of tutorials, data exploration, software development and community networking!
 
-```{admonition} Applications will open around May 8, 2023
+```{admonition} Applications for OHW23 are now open!
 :class: important
 
-Please come back in early May for updates. **We plan to open applications
-starting around May 8, 2023.**
+Applications opened on May 8. 
+**To apply, please [fill out this form](https://form.jotform.com/231165770626154) by the end of June 2, 2023.**  
+Accepted applicants will be notified no later than June 23, 2023.
 ```
 
 The **in-person** event will take place at the [University of Washington](http://www.washington.edu), in Seattle, Washington (US PDT, UTC-7), as an all-day workshop (approximately 9am - 5pm). We expect to accommodate approximately 20-25 participants.
@@ -59,7 +60,7 @@ Participants should familiarize themselves with the materials included in [Pytho
 
 ### Q: I don't know the first thing about version revision/control systems. Can I still apply?
 
-During the hackweek we will use Git and GitHub but you are not expected to be an expert on it. In previous years we have offered refresher in the week prior to the actual OHW event. The organizing committee is deciding whether we can offer this in OHW22. You are welcome to check back here for this info, but we want to emphasize that nothing is better than trying it yourself first -- we recommend the [Software Carpentry lessons](https://swcarpentry.github.io/git-novice/) for learning git basic. 
+During the hackweek we will use Git and GitHub but you are not expected to be an expert on it. In previous years we have offered refresher in the week prior to the actual OHW event. The organizing committee is deciding whether we can offer this in OHW23. You are welcome to check back here for this info, but we want to emphasize that nothing is better than trying it yourself first -- we recommend the [Software Carpentry lessons](https://swcarpentry.github.io/git-novice/) for learning git basic. 
 
 Note that we will require you to create a [GitHub account](https://github.com/) before completing the application.
 

--- a/ohw23/index.md
+++ b/ohw23/index.md
@@ -13,11 +13,10 @@ Join us for five days of hands-on tutorials, data exploration, software developm
 
 See the [OHW21 program](https://oceanhackweek.org/ohw-resources) (a hybrid event) to get a better sense of the usual activities and how they're organized.
 
-```{admonition} Applications will open around May 8, 2023
+```{admonition} Applications for OHW23 are now open!
 :class: important
 
-Please come back in early May for updates. **We plan to open applications
-starting around May 8, 2023.** See the [Information for Applicants page](./applicants).
+Visit the [Information for Applicants page](./applicants) for more information, including the link to the application and an FAQ about the event and the application.
 ```
 
 <!---


### PR DESCRIPTION
Applications are now open: Updated front page, ohw23 main page and Information for Applicants page.

I adapted the text and styles from OHW22, when applications opened. For reference (and in case there's still something helpful there), I looked through these two PR's:
- #138. Created in preparation for the day when applications opened.
- #141. Created a few days later, updating the Applicants FAQ

I didn't look closely at the introduction text from the application form (see https://github.com/oceanhackweek/ohw23-admin/issues/5). Let's do that. There may be text there that we should use to update the information in the Information for Applicants page. We may also need to tweak other pages. 

**This PR will be merged only once the application form is made live on Monday May 8. Let's also review other relevant content before merging the PR.**