### PR TITLE
Add mailing list to Contact Us

### DIFF
--- a/about/contact.md
+++ b/about/contact.md
@@ -11,7 +11,7 @@ Are you interested in learning more about OceanHackWeek, helping out with the ne
 
 ## Mailing list
 
-To generally stay in touch, you can sign up for our email list. This is also the best way to know when we are planning an event and open applications.
+Sign up for our email announcements list to stay in touch. This is also the best way to know when we are planning an event and open applications.
 
 We send out only a few emails a year, mainly as we're planning our next event, as we are also suffering from overflowing inbox syndrome.
 

--- a/about/contact.md
+++ b/about/contact.md
@@ -3,9 +3,30 @@
 Are you interested in learning more about OceanHackWeek, helping out with the next event, or learning about the next event and how to prepare a strong application? You can:
 
 - Look over this web site, both general pages and [past events](pasthackweeks)
+- Sign up for our email list below
 - Write to us at [info@oceanhackweek.org](mailto:info@oceanhackweek.org).
 - Post a comment or question on the [OceanHackWeek GitHub Discussions](https://github.com/orgs/oceanhackweek/discussions) to engage a larger fraction of the OceanHackWeek community
 - Find us on Twitter at [https://twitter.com/oceanhackweek](https://twitter.com/oceanhackweek)
 - Look up our [FAQ for Applicants](../ohw22/applicants.md#faqs). Most of the FAQ entries are relevant for most years, but bear in mind that we update the FAQ every year to reflect the event being planned.
+
+## Mailing list
+
+To generally stay in touch, you can sign up for our email list. This is also the best way to know when we are planning an event and open applications.
+
+We only send out only a few emails a year, mainly as we're planning our next event, as we are also suffering from overflowing inbox syndrome.
+
+<script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/embed/v2.js"></script>
+
+<script>
+  hbspt.forms.create({
+    region: "na1",
+    portalId: "23784201",
+    formId: "5de6feec-5bb3-457e-a84c-1cc9c7214d52"
+  });
+</script>
+
+_If you can't see the form, you can also access it [here](https://share.hsforms.com/1Xeb-7FuzRX6oTBzJxyFNUge5s09)._
+
+______________________________________________________________________
 
 It's hard to remember all these options without referring back to this page. You can always find those links at the top right of the web site, through this set of icons: ![website-contact-icons](../assets/images/website-contact-icons.png)

--- a/about/contact.md
+++ b/about/contact.md
@@ -13,7 +13,7 @@ Are you interested in learning more about OceanHackWeek, helping out with the ne
 
 To generally stay in touch, you can sign up for our email list. This is also the best way to know when we are planning an event and open applications.
 
-We only send out only a few emails a year, mainly as we're planning our next event, as we are also suffering from overflowing inbox syndrome.
+We send out only a few emails a year, mainly as we're planning our next event, as we are also suffering from overflowing inbox syndrome.
 
 <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/embed/v2.js"></script>
 

--- a/conf.py
+++ b/conf.py
@@ -41,7 +41,7 @@ exclude_patterns = [
     "README.md",
     "jupyter_execute/**/*",
     "_InstructionSiteUpdates.md",
-    "_build/**"
+    "_build/**",
 ]
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
@@ -59,9 +59,9 @@ html_theme_options = {
     "search_bar_text": "Search this site...",
     # "google_analytics_id": "",
     "navbar_end": [
-                    # "search-field.html", 
-                   "navbar-icon-links"
-                   ],
+        # "search-field.html",
+        "navbar-icon-links"
+    ],
     "icon_links": [
         {
             "name": "GitHub",
@@ -84,13 +84,13 @@ html_theme_options = {
             "icon": "fab fa-youtube-square",
         },
         {
-            "name": "Email", 
-            "url": "mailto:info@oceanhackweek.org", 
-            "icon": "fas fa-envelope"
+            "name": "Email",
+            "url": "/about/contact/",
+            "icon": "fas fa-envelope",
         },
     ],
     "use_edit_page_button": True,
-    "header_links_before_dropdown": 3
+    "header_links_before_dropdown": 3,
 }
 html_scaled_image_link = False
 
@@ -146,12 +146,7 @@ extensions += ["ablog"]
 # Temporarily stored as off until we fix it
 jupyter_execute_notebooks = "off"  # TODO test
 
-nb_custom_formats = {
-    ".Rmd": [
-        "jupytext.reads",
-        {"fmt": "Rmd"}
-    ]
-}
+nb_custom_formats = {".Rmd": ["jupytext.reads", {"fmt": "Rmd"}]}
 
 
 def setup(app):


### PR DESCRIPTION
Adds a [Hubspot form](https://app.hubspot.com/submissions/23784201/form/5de6feec-5bb3-457e-a84c-1cc9c7214d52/performance?redirectUrl=https%3A%2F%2Fapp.hubspot.com%2Fforms%2F23784201%2F) to the Contact Us page, so folks can sign up for our mailing list/get added to Hubspot.

Also changes the email icon in the header to go to the contact us page, so we can try to get more folks to the signup form, rather than just emailing the general inbox.

[Netlify preview](https://deploy-preview-255--oceanhackweek-preview.netlify.app/about/contact)

The GDPR/privacy boilerplate ends up taking up a good bit of the page, but should help keep us out of trouble.

<img width="1212" alt="image" src="https://github.com/oceanhackweek/oceanhackweek.github.io/assets/1296209/a235baa4-9e08-4f35-96f5-f2df3e2e8b7a">

After submitting:

<img width="817" alt="image" src="https://github.com/oceanhackweek/oceanhackweek.github.io/assets/1296209/264ce71f-5013-46bc-ac83-c47892e2448d">

And we send an email from info@ which should help train folks spam filters:

<img width="703" alt="image" src="https://github.com/oceanhackweek/oceanhackweek.github.io/assets/1296209/bea132f5-8864-4dc4-8c74-8767dc2ce3df">
