### PR TITLE
Fix new email icon link

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -85,7 +85,7 @@ html_theme_options = {
         },
         {
             "name": "Email",
-            "url": "/about/contact/",
+            "url": "/about/contact.html",
             "icon": "fas fa-envelope",
         },
     ],


### PR DESCRIPTION
Looks like the wrong url was used in the last PR