### PR TITLE
transfer tutorials-index from ohw22 to ohw23, embellish index with youtube link

### DIFF
--- a/ohw23/tutorials-index/data-access-in-python.md
+++ b/ohw23/tutorials-index/data-access-in-python.md
@@ -1,0 +1,10 @@
+# Data access in Python
+
+```{toctree}
+
+../tutorials/01-Tue/00-data-access-in-python/00-data-access.ipynb
+../tutorials/01-Tue/00-data-access-in-python/01-extras-https.ipynb
+../tutorials/01-Tue/00-data-access-in-python/02-extras-data-clean-up.ipynb
+../tutorials/01-Tue/00-data-access-in-python/03-extras-argopy-erddap.ipynb
+../tutorials/01-Tue/00-data-access-in-python/04-extras-erddapy_saildrone.ipynb
+```

--- a/ohw23/tutorials-index/data-access-in-r.md
+++ b/ohw23/tutorials-index/data-access-in-r.md
@@ -1,0 +1,7 @@
+# Data access in R
+
+```{toctree}
+../tutorials/01-Tue/00-data-access-in-R/01_data_access.Rmd
+../tutorials/01-Tue/00-data-access-in-R/02_get_nbdc.Rmd
+../tutorials/01-Tue/00-data-access-in-R/03_get_nao.Rmd
+```

--- a/ohw23/tutorials-index/data-vis-in-python.md
+++ b/ohw23/tutorials-index/data-vis-in-python.md
@@ -1,0 +1,13 @@
+# Data visualization in Python
+
+```{toctree}
+
+../tutorials/02-Wed/01-data-visualization-in-python/tutorial/index.ipynb
+../tutorials/02-Wed/01-data-visualization-in-python/tutorial/00_Setup.ipynb
+../tutorials/02-Wed/01-data-visualization-in-python/tutorial/01_Overview.ipynb
+../tutorials/02-Wed/01-data-visualization-in-python/tutorial/02_Building_Panels.ipynb
+../tutorials/02-Wed/01-data-visualization-in-python/tutorial/03_Interlinked_Panels.ipynb
+../tutorials/02-Wed/01-data-visualization-in-python/tutorial/04_Basic_Plotting.ipynb
+../tutorials/02-Wed/01-data-visualization-in-python/tutorial/05_Composing_Plots.ipynb
+
+```

--- a/ohw23/tutorials-index/espanol/index.md
+++ b/ohw23/tutorials-index/espanol/index.md
@@ -1,0 +1,6 @@
+# Espanol Tutorials
+
+```{toctree}
+python-cientifico
+../../tutorials/optional/espanol/datos-espaciales-tidy/Notas.Rmd
+```

--- a/ohw23/tutorials-index/espanol/python-cientifico.md
+++ b/ohw23/tutorials-index/espanol/python-cientifico.md
@@ -1,0 +1,8 @@
+# Python Cientifico
+
+```{toctree}
+Intro to Python <../../tutorials/optional/espanol/python-cientifico/intro_to_python_ohw2022.ipynb>
+Read tabular data<../../tutorials/optional/espanol/python-cientifico/read_tabulardata.ipynb>
+Intro to Plotting <../../tutorials/optional/espanol/python-cientifico/Intro_to_plot.ipynb>
+Intro to NetCDF <../../tutorials/optional/espanol/python-cientifico/intro_to_netcdf.ipynb>
+```

--- a/ohw23/tutorials-index/index.md
+++ b/ohw23/tutorials-index/index.md
@@ -1,0 +1,16 @@
+# Tutorials
+
+The universe of coding online tutorials is vast, but here we have assembled a listing of tutorials delivered at past Ocean Hack Weeks.  Many of these tutorials were recorded and can be found on the [Ocean Hack Week YouTube channel](https://www.youtube.com/results?search_query=oceanhackweek).
+
+```{toctree}
+:maxdepth: 1
+
+../../resources/tutorials/getting_started
+../tutorials/00-Mon/xarray-in-45-min.ipynb
+data-access-in-python
+data-access-in-r
+data-vis-in-python
+machine-learning-applications
+espanol/index
+../tutorials/optional/managing-conda-envs/README.md
+```

--- a/ohw23/tutorials-index/machine-learning-applications.md
+++ b/ohw23/tutorials-index/machine-learning-applications.md
@@ -1,0 +1,7 @@
+# Machine learning applications
+
+```{toctree}
+../tutorials/03-Thu/00-machine-learning/00-unsupervised-PCA.ipynb
+../tutorials/03-Thu/00-machine-learning/01-unsupervised-kmeans.ipynb
+../tutorials/03-Thu/00-machine-learning/02-supervised-knn.ipynb
+```


### PR DESCRIPTION
Hello @oceanhackweek/website

The tutorials group would like to resuse the OHW22 tutorials page for OHW23, and we would liek to include a link tot he OHW Youtube channel.  We think this is the best approach at this time, and we can update as needed between now and Aug 7.

I think I have faithfully followed the [update instructions](https://github.com/oceanhackweek/oceanhackweek.github.io/blob/source/_InstructionSiteUpdates.md) to make a pull request. This branch, `tutorials-23`, changes very little but brings the content into the owh23 directory and embellishes the index page.  I couldn't figure out how to add a link to the 'Section Navigation' section of the [OWH23 landing page](https://oceanhackweek.org/ohw23/index.html), but I am happy to do so if nudged in the right direction.  