### PR TITLE
Update NB git puller link for 23

### DIFF
--- a/resources/prep/jupyterhub.md
+++ b/resources/prep/jupyterhub.md
@@ -45,13 +45,13 @@ The nbgitpuller link is magical, but it can't detect which profile you are curre
 
 :::{tab-item} Python
 
-[Pull tutorial repo for the Python profile](https://oceanhackweek.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=lab%2Ftree%2Fohw-tutorials%2F&branch=OHW22)
+[Pull tutorial repo for the Python profile](https://oceanhackweek.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=lab%2Ftree%2Fohw-tutorials%2F&branch=OHW23)
 
 :::
 
 :::{tab-item} R
 
-[Pull tutorial repo for the R profile](https://oceanhackweek.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=rstudio%2F&branch=OHW22)
+[Pull tutorial repo for the R profile](https://oceanhackweek.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=rstudio%2F&branch=OHW23)
 
 :::
 


### PR DESCRIPTION
Updated NB git puller link for the OHW23 branch of the tutorials repo.