### PR TITLE
Update projects guidance

### DIFF
--- a/ohw23/projects/index.md
+++ b/ohw23/projects/index.md
@@ -2,7 +2,12 @@
 
 ## How will the projects be conducted?
 
-Instructions and guidance are coming soon! We encourage project ideas from participants; details to follow in the near future on how to propose an idea.
+We encourage project ideas from participants! Feel free to discuss existing or new project ideas **#ohw23_project** Slack channel prior to the event. Once ideas begin to gel and collaborative groups begin to form, the group can start getting into the weeds using a [Google Jamboard](https://jamboard.google.com/d/1lOgVwnqQLvNRPAOEVEGnWXm8FSTuPYQWbteptKrslTM/viewer?f=0). Later the group needs to create and present a visual [elevator speech](https://en.wikipedia.org/wiki/Elevator_pitch) using one [Google Slide](https://docs.google.com/presentation/d/1eQKSdFHNGMDqGJMY4d-yGnNm4UrUj5kIS2mLQGPMZC8/edit#slide=id.p), create a project Slack channel that starts with `ohw23_proj_` (say, `ohw23_proj_upwelling`), and create a Github repository (follow [these instructions](https://oceanhackweek.org/resources/prep/git.html#create-a-project-repository)). 
+
+We've scheduled part of Day 1 and the early part of Day 2 for project ideation. After that, time not allocated to shared tutorials and discussions may be devoted to working on the projects - hacking!
+
+Please look over the information below for guidance about projects, how to get started and the motivations for working on projects.
+
 
 <!--We have put together a [few questions](https://github.com/oceanhackweek/discussions/discussions/categories/ohw22-project-planning) that can help you propose a project in [GitHub discussions](https://github.com/oceanhackweek/discussions/discussions/categories/ohw22-project-planning).
 


### PR DESCRIPTION
Replaced the first section, the one that's specific to OHW23, with the text about projects from the 2nd onboarding email. Plus some edits especially to weave in relevant information available on the website.