### PR TITLE
Update ohw23 projects list, project members & Australian presentations

### DIFF
--- a/ohw23/projects/projects_thisyear.md
+++ b/ohw23/projects/projects_thisyear.md
@@ -6,7 +6,7 @@ Projects from OceanHackWeek 2023.
 
 ### 1. Oil spill monitoring: segmentation of satellite imagery
 
-- Project members: TO-BE-FILLED-IN!
+- Project members: Amanda Dash, Maria Paula Graziotto, Jose Roberto Garcia, Jaelyn Bos, Anand Sekar
 - GitHub repository: [https://github.com/oceanhackweek/ohw23_proj_oil](https://github.com/oceanhackweek/ohw23_proj_oil)
 - [Presentation recording](https://youtu.be/cSMewT6P9LI)
 <!-- - [Project pitch slide](https://docs.google.com/presentation/d/1eQKSdFHNGMDqGJMY4d-yGnNm4UrUj5kIS2mLQGPMZC8/edit#slide=id.g239da66eda5_26_0)  -->
@@ -16,33 +16,33 @@ Projects from OceanHackWeek 2023.
 - Project members: Catherine Courtier, Mackenzie Fiss, Denisse Fierro Arcos, Paulo Freire, Jade Hong, Caitlin O’Brien, Mary Solokas, Laura Tsang, Eli Holmes, Tylar Murray, Ben Tupper
 - Product: [Marine Species Distribution tutorial](https://oceanhackweek.org/ohw23_proj_marinesdms/)
 - GitHub repository: [https://github.com/oceanhackweek/ohw23_proj_marinesdms](https://github.com/oceanhackweek/ohw23_proj_marinesdms)
-- [Presentation recording](https://youtu.be/6QGf7lvykC0)
+- Presentation recordings: [Seattle + Virtual](https://youtu.be/6QGf7lvykC0) and [Australia](https://youtu.be/j4C2Y5GurQU?list=PLVH-j9gOscWmTQNctTx07pf97BRuUxCBX&t=924)
 - [Project pitch slide](https://docs.google.com/presentation/d/1eQKSdFHNGMDqGJMY4d-yGnNm4UrUj5kIS2mLQGPMZC8/edit#slide=id.g25f8e87bf15_11_0)
 
 ### 3. Inertial oscillations in the marginal ice zone
 
-- Project members: TO-BE-FILLED-IN!
+- Project members: Laura Crews, Colin Sauze, Dalton Sasaki, Michael Cappola, Alex Kerney, Myranda Shirk, Aditya Sharma
 - GitHub repository: [https://github.com/oceanhackweek/ohw23_proj_sea_ice_oscillations](https://github.com/oceanhackweek/ohw23_proj_sea_ice_oscillations)
 - [Presentation recording](https://youtu.be/A50HV-8ex8I)
 <!-- - [Project pitch slide](https://docs.google.com/presentation/d/1eQKSdFHNGMDqGJMY4d-yGnNm4UrUj5kIS2mLQGPMZC8/edit#slide=id.g239da66eda5_18_7)  -->
 
 ### 4. Machine learning for Argo Data QC
 
-- Project members: TO-BE-FILLED-IN!
+- Project members: Mehrnoush Kharghani, Rob Urick, Dina Soltain Tehrani, Tobias Ferreira
 - GitHub repository: [https://github.com/oceanhackweek/ohw23_proj_argo_ml](https://github.com/oceanhackweek/ohw23_proj_argo_ml)
 - [Presentation recording](https://youtu.be/1oFdLZPHUSA)
 <!-- - [Project pitch slide](https://docs.google.com/presentation/d/1eQKSdFHNGMDqGJMY4d-yGnNm4UrUj5kIS2mLQGPMZC8/edit#slide=id.g25fbb98e25a_14_0) -->
 
 ### 5. Benthic habitat mapping (image processing/seabed classification)
 
-- Project members: TO-BE-FILLED-IN!
+- Project members: Siddhi Joshi, Abdulla Alson Athif, Minh Phan, Valentina Staneva
 - GitHub repository: [https://github.com/oceanhackweek/ohw23-proj-habitatmapping](https://github.com/oceanhackweek/ohw23-proj-habitatmapping)
 - [Presentation recording](https://youtu.be/Lml4rROa91Q)
 <!-- - [Project pitch slide](https://docs.google.com/presentation/d/1eQKSdFHNGMDqGJMY4d-yGnNm4UrUj5kIS2mLQGPMZC8/edit#slide=id.g25fbb98e25a_42_0) -->
 
-### 6. Mooring processing and data page
+### 6. Mooring processing and data page ("fancy moorings")
 
-- Project members: TO-BE-FILLED-IN!
+- Project members: Seth Travis, Lu Guan, Samantha Huntington, Andrea Hilborn, Hafeez Opeyemi Oladejo, Tobias Ferreira, Veronica Martinez, Johnathan Evanilla, Halley McVeigh, Hameed Ajibade, Christian Sarason, Danilo Silva
 - GitHub repository: [https://github.com/oceanhackweek/ohw23_proj_fancymoorings](https://github.com/oceanhackweek/ohw23_proj_fancymoorings)
 - Product: [Pacific Moorings Page](https://oceanhackweek.org/ohw23_proj_fancymoorings/)
 - [Presentation recording](https://youtu.be/90t6h36-BOQ)
@@ -52,7 +52,7 @@ Projects from OceanHackWeek 2023.
 
 - Project members: Jiarui Yu, Paula Birocchi, Boris Shapkin, Alex Slonimer, Dafrosa Kataraihya, Hao Tang, Danyang Li, Chandrama Sarker, Zhengxi Zhou
 - GitHub repository: [https://github.com/oceanhackweek/ohw23_proj_sst](https://github.com/oceanhackweek/ohw23_proj_sst)
-- [Presentation recording](https://youtu.be/ySfmD5JNVxo)
+- Presentation recordings: [Seattle + Virtual](https://youtu.be/ySfmD5JNVxo) and [Australia](https://youtu.be/j4C2Y5GurQU?list=PLVH-j9gOscWmTQNctTx07pf97BRuUxCBX&t=1090)
 - [Presentation Slide](https://docs.google.com/presentation/d/1uUAIsuj9bxOFMVeIG_h5Bs-ZGDrRodldlz2FHfj4TbE/edit#slide=id.p)
 <!-- - [Project pitch slide](https://docs.google.com/presentation/d/1eQKSdFHNGMDqGJMY4d-yGnNm4UrUj5kIS2mLQGPMZC8/edit#slide=id.g239da66eda5_25_5) -->
 
@@ -61,30 +61,24 @@ Projects from OceanHackWeek 2023.
 
 ### Variability of the suppression of South Australian upwelling
 
-- Project members:
+- Project members: Natalia Ribeiro, Marty Hidas, Vini Salazar, Duphrin Joseph, Alessio Arena, Catherine Kim
 - GitHub repository: [https://github.com/oceanhackweek/ohw23_proj_SAupwelling](https://github.com/oceanhackweek/ohw23_proj_SAupwelling)
-- Presentation recording(s)
+- [Presentation recording](https://youtu.be/j4C2Y5GurQU?list=PLVH-j9gOscWmTQNctTx07pf97BRuUxCBX&t=1791)
 
 ### Direct geo referencing drone images
 
-- Project members:
+- Project members: Diana Vargas Ortega, Paul Branson, Nick Mortimer, Abdulla Alson Athif
 - GitHub repository: [https://github.com/oceanhackweek/ohw23_proj_drone_georef](https://github.com/oceanhackweek/ohw23_proj_drone_georef)
-- Presentation recording(s)
+- [Presentation recording](https://youtu.be/j4C2Y5GurQU?list=PLVH-j9gOscWmTQNctTx07pf97BRuUxCBX&t=424)
 
 ### Bioinformatic pipelines for standardized output
 
-- Project members:
+- Project members: Cindy Bessey, Vini Salazar
 - GitHub repository: [https://github.com/oceanhackweek/ohw23_proj_amplicon](https://github.com/oceanhackweek/ohw23_proj_amplicon)
 - Presentation recording(s)
 
 ### Passive acoustics monitoring
 
-- Project members:
+- Project members: Lucille Chapuis, Minh Phan
 - GitHub repository: [https://github.com/oceanhackweek/ohw23-proj-pamproject](https://github.com/oceanhackweek/ohw23-proj-pamproject)
-- Presentation recording(s)
-
-### Investigating the Indonesian throughflow
-
-- Project members:
-- GitHub repository: NO GITHUB REPOSITORY FOUND. MAYBE THIS PROJECT DID NOT GO THROUGH?
-- Presentation recording(s)
+- [Presentation recording](https://youtu.be/j4C2Y5GurQU?list=PLVH-j9gOscWmTQNctTx07pf97BRuUxCBX&t=3)


### PR DESCRIPTION
- Links to project presentation recordings from Australia group
- Add missing project members for all projects, based on names listed at the start of each recording (or a github repo, for one Australia project that didn't have a recording)
- Remove the Indonesia project that apparently never happened