### PR TITLE
Add OHW22 projects list page

### DIFF
--- a/ohw22/projects/index.md
+++ b/ohw22/projects/index.md
@@ -6,8 +6,20 @@ We have put together a [few questions](https://github.com/oceanhackweek/discussi
 
 On Monday August 15th we will have a brief “project setup” session for an overview of all projects already proposed up to that point, and give another opportunity to pitch new ideas that may be formed throughout the day. Project proposals must be submitted by the end of this day (Day 1). Each satellite may have its own, specific deadline time, so please connect with your satellite or the global event for details.
 
+## OHW22 projects list
+
+Check out the [projects that formed this year!](projects_thisyear.md)
+
 ## Project overview
 
 ```{include} ../../resources/projects.md
 :start-after: "# Project Overview"
+```
+
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+./projects_thisyear
 ```

--- a/ohw22/projects/projects_thisyear.md
+++ b/ohw22/projects/projects_thisyear.md
@@ -1,0 +1,123 @@
+# OHW22 Projects List
+
+Projects from OceanHackWeek 2022.
+
+## 1. Arctic observing data access and visualization
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-arcticdata
+- [Presentation recording](https://youtu.be/cSMewT6P9LI)
+- Project members: 
+
+## 2. Kerchunk! Bless you
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-kerchunk
+- [Presentation recording](https://youtu.be/ac2os0Z8FOM)
+- Project members: 
+
+## 3. Mapping eddy flow structures using GCM-Filters
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-gcmfilters
+- [Presentation recording](https://youtu.be/Ow4fD9Mm-f0)
+- Project members: 
+
+## 4. Ocean Database for South Atlantic
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj_SA_ocean_db
+- [Presentation recording](https://youtu.be/UP0CCFmXoTg)
+- Project members: 
+
+## 5. Lightweight ocean passive acoustic data query
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-passive-acoustics-data-query
+- [Presentation recording](https://youtu.be/b9T5Aj8TMIA)
+- Project members: 
+
+## 6. XYZT - Streamline extraction of data
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-xyzt
+- [Presentation recording](https://youtu.be/ScgDwZyuSvI)
+- Project members: 
+
+## 7. ENSO prediction using Deep Learning
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-ENSO_Prediction
+- [Presentation recording](https://youtu.be/bdiHeL1nSE4)
+- Project members: 
+
+## 8. Radar Doppler Spectra imaging data quality control
+
+- GitHub repository: 
+- [Presentation recording](https://youtu.be/HrV0Km8e88M)
+- Project members: 
+
+## 9. Assessing ocean drivers of coastal physical processes (in Spanish)
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-oleaje-costeros
+- [Presentation recording](https://youtu.be/LeYIzxp4DUY)
+- Project members: 
+
+## 10. Nutrient Profile Clustering
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-clusters-nutrients
+- [Presentation recording](https://youtu.be/2Pvaa3RnZgw)
+- Project members: 
+
+## 11. Unsupervised classification of Flow Cytometry TS data
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-flow-cytometry
+- [Presentation recording](https://youtu.be/vTJbPHvP-Hk)
+- Project members: 
+
+## 12. SiMCosta Buoy
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-simcosta
+- [Presentation recording](https://youtu.be/DtwRaHLRV0Q)
+- Project members: 
+
+## 13. Biofouled
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-biofouled
+- [Presentation recording](https://youtu.be/SLyNhOlqHMM)
+- Project members: 
+
+## 14. Langrangian dispersion
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-lagrange_points
+- [Presentation recording](https://youtu.be/KMe9MlexZ-E)
+- Project members: 
+
+## 15. Extreme events / anomaly detection
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-Extreme_event
+- [Presentation recording](https://youtu.be/M7gwjNd0uOI)
+- Project members: 
+
+## 16. Seismic Wave Speed From an Alaska Earthquake
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-earthquakes
+- [Presentation recording](https://youtu.be/7dXqJvyoZ7A)
+- Project members: 
+
+## 17. Evaluation of biological indicators in the Galapagos (in Spanish)
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-biodiversity-indicators
+- [Presentation recording](https://youtu.be/ZegU4DX3u1M)
+- Project members: 
+
+## 18. The ultimate collection of plotting example notebooks 
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-plot_this_and_that
+- Presentation recording
+- Project members: 
+
+## 19. FrontFinder
+
+- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-front-finder
+- Presentation recording
+- Project members: 
+
+## 20. Project Video Data Processing
+
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-video-data-processing](https://github.com/oceanhackweek/ohw22-proj-video-data-processing/tree/dev)
+- Presentation recording
+- Project members: 


### PR DESCRIPTION
Came up with 20 projects. Includes all projects that had a recording plus project repos that developed what looked like meaningful content. Excludes 2 project repos that had no meaningful content or a recording.

Used the projects list page template from OHW23.