### PR TITLE
In OHW22 projects list, made the GH urls real links

### DIFF
--- a/ohw22/projects/projects_thisyear.md
+++ b/ohw22/projects/projects_thisyear.md
@@ -4,43 +4,43 @@ Projects from OceanHackWeek 2022.
 
 ## 1. Arctic observing data access and visualization
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-arcticdata
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-arcticdata](https://github.com/oceanhackweek/ohw22-proj-arcticdata)
 - [Presentation recording](https://youtu.be/cSMewT6P9LI)
 - Project members: 
 
 ## 2. Kerchunk! Bless you
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-kerchunk
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-kerchunk](https://github.com/oceanhackweek/ohw22-proj-kerchunk)
 - [Presentation recording](https://youtu.be/ac2os0Z8FOM)
 - Project members: 
 
 ## 3. Mapping eddy flow structures using GCM-Filters
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-gcmfilters
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-gcmfilters](https://github.com/oceanhackweek/ohw22-proj-gcmfilters)
 - [Presentation recording](https://youtu.be/Ow4fD9Mm-f0)
 - Project members: 
 
 ## 4. Ocean Database for South Atlantic
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj_SA_ocean_db
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj_SA_ocean_db](https://github.com/oceanhackweek/ohw22-proj_SA_ocean_db)
 - [Presentation recording](https://youtu.be/UP0CCFmXoTg)
 - Project members: 
 
 ## 5. Lightweight ocean passive acoustic data query
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-passive-acoustics-data-query
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-passive-acoustics-data-query](https://github.com/oceanhackweek/ohw22-proj-passive-acoustics-data-query)
 - [Presentation recording](https://youtu.be/b9T5Aj8TMIA)
 - Project members: 
 
 ## 6. XYZT - Streamline extraction of data
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-xyzt
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-xyzt](https://github.com/oceanhackweek/ohw22-proj-xyzt)
 - [Presentation recording](https://youtu.be/ScgDwZyuSvI)
 - Project members: 
 
 ## 7. ENSO prediction using Deep Learning
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-ENSO_Prediction
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-ENSO_Prediction](https://github.com/oceanhackweek/ohw22-proj-ENSO_Prediction)
 - [Presentation recording](https://youtu.be/bdiHeL1nSE4)
 - Project members: 
 
@@ -52,67 +52,67 @@ Projects from OceanHackWeek 2022.
 
 ## 9. Assessing ocean drivers of coastal physical processes (in Spanish)
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-oleaje-costeros
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-oleaje-costeros](https://github.com/oceanhackweek/ohw22-proj-oleaje-costeros)
 - [Presentation recording](https://youtu.be/LeYIzxp4DUY)
 - Project members: 
 
 ## 10. Nutrient Profile Clustering
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-clusters-nutrients
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-clusters-nutrients](https://github.com/oceanhackweek/ohw22-proj-clusters-nutrients)
 - [Presentation recording](https://youtu.be/2Pvaa3RnZgw)
 - Project members: 
 
 ## 11. Unsupervised classification of Flow Cytometry TS data
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-flow-cytometry
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-flow-cytometry](https://github.com/oceanhackweek/ohw22-proj-flow-cytometry)
 - [Presentation recording](https://youtu.be/vTJbPHvP-Hk)
 - Project members: 
 
 ## 12. SiMCosta Buoy
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-simcosta
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-simcosta](https://github.com/oceanhackweek/ohw22-proj-simcosta)
 - [Presentation recording](https://youtu.be/DtwRaHLRV0Q)
 - Project members: 
 
 ## 13. Biofouled
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-biofouled
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-biofouled](https://github.com/oceanhackweek/ohw22-proj-biofouled)
 - [Presentation recording](https://youtu.be/SLyNhOlqHMM)
 - Project members: 
 
 ## 14. Langrangian dispersion
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-lagrange_points
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-lagrange_points](https://github.com/oceanhackweek/ohw22-proj-lagrange_points)
 - [Presentation recording](https://youtu.be/KMe9MlexZ-E)
 - Project members: 
 
 ## 15. Extreme events / anomaly detection
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-Extreme_event
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-Extreme_event](https://github.com/oceanhackweek/ohw22-proj-Extreme_event)
 - [Presentation recording](https://youtu.be/M7gwjNd0uOI)
 - Project members: 
 
 ## 16. Seismic Wave Speed From an Alaska Earthquake
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-earthquakes
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-earthquakes](https://github.com/oceanhackweek/ohw22-proj-earthquakes)
 - [Presentation recording](https://youtu.be/7dXqJvyoZ7A)
 - Project members: 
 
 ## 17. Evaluation of biological indicators in the Galapagos (in Spanish)
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-biodiversity-indicators
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-biodiversity-indicators](https://github.com/oceanhackweek/ohw22-proj-biodiversity-indicators)
 - [Presentation recording](https://youtu.be/ZegU4DX3u1M)
 - Project members: 
 
 ## 18. The ultimate collection of plotting example notebooks 
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-plot_this_and_that
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-plot_this_and_that](https://github.com/oceanhackweek/ohw22-proj-plot_this_and_that)
 - Presentation recording
 - Project members: 
 
 ## 19. FrontFinder
 
-- GitHub repository: https://github.com/oceanhackweek/ohw22-proj-front-finder
+- GitHub repository: [https://github.com/oceanhackweek/ohw22-proj-front-finder](https://github.com/oceanhackweek/ohw22-proj-front-finder)
 - Presentation recording
 - Project members: 
 


### PR DESCRIPTION
Missed making the GH project repo urls as links in the previous PR.