### PR TITLE
Hide outdated About > Task Groups page

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -55,7 +55,6 @@ The hackweek model was spearheaded by the successful [*Astro-*](http://astrohack
 
 steering_committee
 ohw-charter
-task-groups
 pasthackweeks
 Testimonials <testimonials>
 code-of-conduct


### PR DESCRIPTION
I think the consensus was to remove the About > Task Groups page. In this PR, I'm "hiding" it -- removing it from the About table of content so it's not findable anymore.