### PR TITLE
OHW24 volunteer recruitment page and related OHW24 updates

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,10 +6,10 @@ description: OceanHackWeek home
 
 # OceanHackWeek (OHW)
 
-:::{admonition} Stay tuned for OceanHackWeek 2024
+:::{admonition} Volunteer to help with OceanHackWeek 2024!
 :class: important
 
-Check back here in early 2024 for updates on OceanHackWeek 2024! In the meantime, [check out our past events,](about/pasthackweeks) including [OHW23](ohw23/index).
+OceanHackWeek 2024 will be August 26 - 30! We are recruiting Organizing Committee members, tutorial instructors, and project mentors for the event. [**Go to the OceanHackWeek 2024 page to learn more and apply.**](ohw24/index)
 
 <!-- 
 ```{button-link} ohw23/
@@ -152,7 +152,7 @@ Thanks to our sponsors that have made OceanHackWeek possible over the last sever
 :hidden:
 
 about/index.md
-OceanHackWeek 2023 <ohw23/index.md>
+OceanHackWeek 2024 <ohw24/index.md>
 resources/index.md
 about/pasthackweeks.md
 ```

--- a/ohw24/index.md
+++ b/ohw24/index.md
@@ -1,0 +1,63 @@
+# OceanHackWeek 2024 (OHW24)
+
+**Passionate about data science in oceanography, love collaborative project work and interested in helping organize & host OceanHackWeek 2024? Please read on!**
+
+**We are recruiting Organizing Committee members, tutorial instructors, and project mentors for OceanHackWeek 2024!**
+
+We are currently recruiting three different roles:
+
+- **Organizing Committee members**, who oversee organizing all aspects of the workshop including planning the schedule, selecting tutorials, applicant review and selection, cyberinfrastructure decisions, and logistics.
+- **Tutorial instructors**, who will deliver tutorials live during the workshop.
+- **Project mentors**, who mentor the project team during the workshop. Mentors may bring initial project ideas for participants to brainstorm further toward setting up a project, or serve as mentors for project ideas proposed by participants themselves.
+
+**OceanHackWeek 2024 will be August 26th - 30th.** We will have two in-person events, held at Bigelow Laboratory for Ocean Sciences in Maine, US, and in Australia (location TBD). We are working on securing more funding to support project mentors and tutorial instructors to attend the in-person event, but currently we are unsure of the level of available funding. We ask you to consider your interest with this caveat in mind.
+
+## Further details for each role
+
+### Organizing Committee members
+
+- Key responsibilities
+  - Work collaboratively to plan and organize the workshop. The following is a non-exhaustive list of tasks typically carried out by the Organizing Committee:
+    - Develop the schedule, deciding on the balance of tutorials and project work
+    - Promote and advertise OHW
+    - Select participants
+    - Set up the cyberinfrastructure to support the event
+    - Recruit helpers (instructors, project mentors, general helpers)
+    - Distribute and promote post event surveys 
+  - The Organizing Committee uses a distributed leadership model with task groups focused on: event coordination, participant application/selection, communication, tutorials, projects, cyberinfrastructure. Organizing Committee members are expected to participate in at least 1 and at most 3 task groups.
+  - Prepare for and conscientiously participate in Organizing Committee and task group meetings and activities. 
+  - Support OHW's [mission & vision](../about/index).
+  - Exemplify OHW's [Code of Conduct](../about/code-of-conduct).
+- Time commitment
+  - The Organizing Committee meets for approximately 6 months, starting in March. Initially, the Committee will meet every 2 weeks, until 2 months before the event, when they will switch to weekly meetings. The Committee will also hold a debrief meeting after the event and look at post event survey results.
+  - The Organizing Committee members do not need to attend the in-person event.
+
+### Tutorial instructors
+
+- Key responsibilities
+  - Develop an executable tutorial approximately 45 minutes to 1 hour in length
+  - Upload the tutorial materials to the OHW GitHub and work with the OHW Cyberinfrastructure task group to validate environment requirements
+  - Test the tutorial on the OHW JupyterHub to ensure participants can actively follow along.
+- Time commitment
+  - Deliver the tutorial live during OHW (either virtually or in-person).
+
+### Project mentors
+
+- Key responsibilities
+  - Encourage and guide the project team to ensure participation by every team member: e.g., mitigate situations where extroverts dominate discussions, suggest ways to balance tasks so that everyone feels they have something to contribute
+  - Facilitate project team communication
+  - Monitor and guide the project team's use of GitHub issues and pull requests
+  - Guide the participants in preparing the final project presentation, especially if the team is stuck because the different strands of a project are not coming together semi cleanly.
+  - Provide technical advisory support and help connect participants to others in the OHW community (organizers, instructors, other participants, etc.) who may have relevant expertise.
+  - Provide scientific advisory support if the proposed project is in your broader scientific domains.
+- Time commitment
+  - Attend weekly Organizing Committee meetings for the month before the event.
+  - Be present for the full workshop. 
+  - Participate in a post workshop debrief.
+
+
+:::{admonition} Apply to help with OceanHackWeek 2024!
+:class: important
+
+Please [apply here](https://share.hsforms.com/1wW5CSVglSJyqAyG_EV3vXwe5s09). We will start reviewing applications **on March 11th**. Please direct any questions to <a href="mailto:info@oceanhackweek.org" target="_blank">info@oceanhackweek.org</a>.
+:::


### PR DESCRIPTION
- Created new ohw24 site (`/ohw24` directory) with a single page (the index page) based on the content of the [Google Doc](https://docs.google.com/document/d/11gNd3dTUbZKpYE-Gg25AdQCBQp3WsSOIQxKoNqlybiM/edit) we drafted for recruiting volunteers for ohw24. On that page:
  - Added link to [Hubspot form](https://share.hsforms.com/1wW5CSVglSJyqAyG_EV3vXwe5s09)
  - Added some section organization
  - Where ohw "mission & vision" and code of conduct were mentioned, I turned them into links.
- Updated the front page call out to include the ohw24 dates and point to the volunteer recruitment page
- On the top bar, replaced the link to ohw23 with ohw24

Note: I've removed the outdated About > Task Groups page. See #311 