### PR TITLE
Update website for opening of OHW24 applications

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,6 +8,9 @@ description: OceanHackWeek home
 
 :::{admonition} OceanHackWeek 2024 will be on August 26 - 30!
 :class: important
+
+**Applications for OceanHackWeek 2024 are now open!**
+
 OceanHackWeek 2024 will be an in-person event with two in-person gatherings in Maine, US and Sydney, Australia. Visit the [OHW24 event web site](ohw24/index) for more information,
 including updates about when applications will open!
 

--- a/ohw24/applicants.md
+++ b/ohw24/applicants.md
@@ -9,11 +9,11 @@ permalink: applicant-info.html
 
 OceanHackWeek 2024 (OHW24) is a hands-on, interactive in-person workshop focused on data science in oceanography and fisheries that will be held on **August 26-30, 2024**. Join us for five days of tutorials, data exploration, software development and community networking!
 
-```{admonition} Applications for OceanHackWeek 2024 will open soon!
+```{admonition} Applications for OHW24 are now open!
 :class: important
 
-Please come back in early June for updates. **We plan to open applications
-very soon.**
+Applications opened on June 14. **To apply, please [fill out this form](https://docs.google.com/forms/d/e/1FAIpQLScM_6iV2DPAjaG3gxdDbPfkTRa5yC6Rpnbr1VIXfYK3fzNvDw/viewform) by the end of June 30, 2024.**  
+Accepted applicants will be notified no later than July 9, 2024.
 ```
 
 **See the [main OHW24 page](index) for information about each of the two in-person OHW24 events, in the US and in Australia.**

--- a/ohw24/index.md
+++ b/ohw24/index.md
@@ -12,10 +12,10 @@ The events will be all-day workshops (approximately 9am - 5pm). Join us for five
 
 See the [OHW23 program](https://oceanhackweek.org/ohw23/) (a hybrid event) to get a better sense of the usual activities and how they're organized.
 
-```{admonition} Applications will open soon!
+```{admonition} Applications for OHW24 are now open!
 :class: important
 
-Please come back in early June for updates! See the [Information for Applicants](applicants) page.
+Visit the [Information for Applicants page](./applicants) for more information, including the link to the application and an FAQ about the event and the application.
 ```
 
 ```{admonition} Apply to help with OceanHackWeek 2024!


### PR DESCRIPTION
Applications for OHW24 are now open: Updated front page, ohw24 main page, and Information for Applicants page.

I copied the formatting the OHW23 site, specifically referencing this PR:

- [Update web site for the opening of ohw23 applications #239](https://github.com/oceanhackweek/oceanhackweek.github.io/pull/239)

A quick review by @emiliom, @abkfenris, or @cathmmitchell would be appreciated before merging. 