### PR TITLE
Fix link in instructor-guide.md

### DIFF
--- a/resources/organizing/instructor-guide.md
+++ b/resources/organizing/instructor-guide.md
@@ -42,7 +42,7 @@ Although the content of your tutorial may not seem a lot when presented as stand
 
 Oceanhackweek usualy provides a JupyterHub environment within which participants can run any interactive tutorials. As an instructor you will have to ensure that your tutorial can run within the environment. For that you will need to:
 * provide your github username to the organizing team so that you get added to JupyterHub
-* familiarize yourself with the JupyterHub environment ([JupyterHub Intro](https://github.com/valentina-s/oceanhackweek.github.io/blob/instructor-guide/resources/prep/jupyterhub.md))
+* familiarize yourself with the JupyterHub environment ([JupyterHub Intro](../resources/prep/jupyterhub.md))
 * Identify which packages (and corresponding versions) you will need for the tutorial and provide them to the organizing team so that they are included into an image for building the JupyterHub (those can be PyPi, `conda`/`conda-forge`, R)
 * Contribute your tutorial content to the corresponding OHWYY branch in [https://github.com/oceanhackweek/ohw-tutorials/](https://github.com/oceanhackweek/ohw-tutorials/)
 * Ensure participants have access to the datasets used in the tutorial

--- a/resources/organizing/instructor-guide.md
+++ b/resources/organizing/instructor-guide.md
@@ -42,7 +42,7 @@ Although the content of your tutorial may not seem a lot when presented as stand
 
 Oceanhackweek usualy provides a JupyterHub environment within which participants can run any interactive tutorials. As an instructor you will have to ensure that your tutorial can run within the environment. For that you will need to:
 * provide your github username to the organizing team so that you get added to JupyterHub
-* familiarize yourself with the JupyterHub environment ([JupyterHub Intro](../resources/prep/jupyterhub.md))
+* familiarize yourself with the JupyterHub environment ([JupyterHub Intro](../prep/jupyterhub.md))
 * Identify which packages (and corresponding versions) you will need for the tutorial and provide them to the organizing team so that they are included into an image for building the JupyterHub (those can be PyPi, `conda`/`conda-forge`, R)
 * Contribute your tutorial content to the corresponding OHWYY branch in [https://github.com/oceanhackweek/ohw-tutorials/](https://github.com/oceanhackweek/ohw-tutorials/)
 * Ensure participants have access to the datasets used in the tutorial


### PR DESCRIPTION
Link to JupyterHub instructions was pointing to https://github.com/valentina-s/oceanhackweek.github.io/blob/instructor-guide/resources/prep/jupyterhub.md rather than using a relative link to `../resources/prep/jupyterhub.md`

BTW, great to see this Intructors guide!