### PR TITLE
Batch of new OHW24 pages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
 	path = ohw23/tutorials
 	url = https://github.com/oceanhackweek/ohw-tutorials.git
 	branch = OHW23
+[submodule "ohw24/tutorials"]
+	path = ohw24/tutorials
+	url = https://github.com/oceanhackweek/ohw-tutorials.git
+	branch = OHW24

--- a/conf.py
+++ b/conf.py
@@ -139,7 +139,11 @@ myst_admonition_enable = True
 myst_deflist_enable = True
 myst_heading_anchors = 3
 myst_update_mathjax = False
-myst_enable_extensions = ["substitution", "colon_fence"]
+myst_enable_extensions = [
+    "colon_fence",
+    "strikethrough",
+    "substitution",
+]
 
 extensions += ["ablog"]
 

--- a/index.md
+++ b/index.md
@@ -9,10 +9,6 @@ description: OceanHackWeek home
 :::{admonition} OceanHackWeek 2024 will be on August 26 - 30!
 :class: important
 
-**Applications for OceanHackWeek 2024 are now open!**
-
-OceanHackWeek 2024 will be an in-person event with two in-person gatherings in Maine, US and Sydney, Australia. Visit the [OHW24 event web site](ohw24/index) for more information,
-including updates about when applications will open!
 
 ```{button-link} ohw24/
 :color: primary

--- a/ohw24/index.md
+++ b/ohw24/index.md
@@ -1,6 +1,13 @@
 # OceanHackWeek 2024 (OHW24)
 
-OceanHackWeek 2024 (OHW24) will be held on **August 26-30, 2024** as two in-person events, in East Boothbay, Maine, US and in Sydney, Australia. The US in-person event will take place at the [Bigelow Laboratory for Ocean Sciences](https://www.bigelow.org).
+OceanHackWeek 2024 (OHW24) will be held on **August 26-30, 2024** as two in-person events, in East Boothbay, Maine, US and in Sydney, Australia. The US event will take place at the [Bigelow Laboratory for Ocean Sciences](https://www.bigelow.org).
+
+The OceanHackWeek program consists of hands-on tutorials, visual presentations, and collaborative hack projects throughout a 5-day period.
+
+```{admonition} Technical preparations and background for OceanHackWeek!
+- Please review the ["Preparation" materials](../resources/prep/index.md) covering basic topics like `Git`, `GitHub`, `conda` package management and the OHW `JupyterHub`
+- For tutorials on Python and R scientific tools and techniques that we will use in OceanHackWeek, see the [OHW 2022 tutorials page](../ohw22/tutorials-index/index.md)!
+```
 
 ```{image} ../assets/images/ohw_hacking/ohw21-Bigelow-outing.jpg
 :alt: OHW21 in person, taking a break
@@ -10,7 +17,17 @@ OceanHackWeek 2024 (OHW24) will be held on **August 26-30, 2024** as two in-pers
 
 The events will be all-day workshops (approximately 9am - 5pm). Join us for five days of hands-on tutorials, data exploration, software development, presentations, collaborative hack projects and community networking!
 
-See the [OHW23 program](https://oceanhackweek.org/ohw23/) (a hybrid event) to get a better sense of the usual activities and how they're organized.
+
+## In-person event in Maine
+
+See the [schedules here](schedule.md).
+
+```{admonition} UPDATE THIS INFORMATION TO OHW24 CONTEXT!!
+:class: important
+- See the [ohw23 index page](../ohw23) as a template to content for this page, though the parts about the hybrid nature don't apply
+- Will you list the Australia event here, too?
+- Remove the admonition box below if applications for volunteers have closed
+```
 
 
 
@@ -42,7 +59,7 @@ We are still looking for volunteers to help with OceanHackWeek 2024! Please [app
   </div>
 
   <div class="col-4" style="margin-bottom: 1rem">
- 
+
 ```{image} ../assets/images/logos/GOMO_Horizontal_Lockup_Logo_in_Blue.png
 :alt: GOMO
 :width: 180px
@@ -80,6 +97,10 @@ We are still looking for volunteers to help with OceanHackWeek 2024! Please [app
 :caption: OceanHackWeek 2024 (OHW24)
 :hidden:
 
+schedule
 Organizers <organizers>
+Logistics <logistics/index>
+tutorials-index/index
+Projects <projects/index>
 Information for Applicants <applicants>
 ```

--- a/ohw24/index.md
+++ b/ohw24/index.md
@@ -22,20 +22,13 @@ The events will be all-day workshops (approximately 9am - 5pm). Join us for five
 
 See the [schedules here](schedule.md).
 
-```{admonition} UPDATE THIS INFORMATION TO OHW24 CONTEXT!!
+<!-- ```{admonition} UPDATE THIS INFORMATION TO OHW24 CONTEXT!!
 :class: important
 - See the [ohw23 index page](../ohw23) as a template to content for this page, though the parts about the hybrid nature don't apply
 - Will you list the Australia event here, too?
 - Remove the admonition box below if applications for volunteers have closed
-```
+``` -->
 
-
-
-```{admonition} Apply to help with OceanHackWeek 2024!
-:class: important
-
-We are still looking for volunteers to help with OceanHackWeek 2024! Please [apply here](https://share.hsforms.com/1wW5CSVglSJyqAyG_EV3vXwe5s09). You can direct any questions to <a href="mailto:info@oceanhackweek.org" target="_blank">info@oceanhackweek.org</a>.
-```
 
 
 ## OHW24 Sponsors

--- a/ohw24/logistics/getting_help.md
+++ b/ohw24/logistics/getting_help.md
@@ -32,7 +32,7 @@ You are also welcome to direct message the helpers if you don't feel comfortable
 
 Tune in on Slack for continuous Q&A!
 
-- Ask questions on Slack! Use the `#ohw24-tutorials` channel to ask questions or check out answers to questions others have posed. We will use this same channel every day. Several of us will be monitoring this channel and addressing your questions throughout the tutorials
+- Ask questions on Slack! Use the `#ohw24_tutorials` channel to ask questions or check out answers to questions others have posed. We will use this same channel every day. Several of us will be monitoring this channel and addressing your questions throughout the tutorials
 - **Vote up** questions from others to help the moderators prioritize which questions to ask the speaker during tutorials.
 - Tutorial moderators will mark questions that are best answered by the instructor and ask helpers (and anyone else!) to answer the rest in real time. Then when the instructor ask if there are questions the moderators will read those reserved for the instructor.
 - Zoom Chat will **not** be available. Ask on Slack!

--- a/ohw24/logistics/getting_help.md
+++ b/ohw24/logistics/getting_help.md
@@ -1,0 +1,48 @@
+# Getting Help
+
+We know how overwhelming all of this information can be. Here is some for asking questions and figuring out where to turn for help.
+
+You can ask anything on the Slack `#ohw24_general` channel, any time. Organizers and helpers are monitoring this channel, and some of your fellow hackweek participants may be able to help you! Also, feel free to send a direct message on Slack to any of the organizers or helpers.
+
+## Online Resources
+
+We provide a number of resources to help get you started on our [Resources page](https://oceanhackweek.org/resources/index.html). Please be sure to checks this page out, especially the section on preparation.
+
+
+## Helpdesk
+
+We've set up the `#ohw24_helpdesk` Slack channel to ask technical questions (or other types of questions, if you'd like). 
+
+We will set up some helpdesk Slack user group that you can use to tag your question as, say, about Python. We'll list and describe those groups here. If you know the rough category of help that you may need, please tag one of the helpdesk user groups to get their attention. All help usergroups can be found by typing `@help-` and Slack will prompt with options.
+
+You are also welcome to direct message the helpers if you don't feel comfortable asking questions publicly.
+
+### Slack help groups
+
+- `@help-infrastructure` - For issues regarding the JupyterHub, Slack, Github, and Zoom.
+- `@help-projects` - For help with managing projects, for instance asking how to set up a new repo, or organize meetings.
+- `@help-python` - Questions about Python programming.
+- `@help-r` - Questions about R programming.
+- `@help-ml` - Questions about machine learning.
+- `@help-git` - Questions about git.
+- `@help-tutorials` - For help with tutorial logistics, like cloning the notebooks.
+- `@help-website` - If there are any issues with the website tag us to take a look.
+
+## During tutorials
+
+Tune in on Slack for continuous Q&A!
+
+- Ask questions on Slack! Use the `#ohw24-tutorials` channel to ask questions or check out answers to questions others have posed. We will use this same channel every day. Several of us will be monitoring this channel and addressing your questions throughout the tutorials
+- **Vote up** questions from others to help the moderators prioritize which questions to ask the speaker during tutorials.
+- Tutorial moderators will mark questions that are best answered by the instructor and ask helpers (and anyone else!) to answer the rest in real time. Then when the instructor ask if there are questions the moderators will read those reserved for the instructor.
+- Zoom Chat will **not** be available. Ask on Slack!
+- You will be muted at the start of the tutorial presentation. The moderator will review questions on Slack and ask the questions to the instructor during Q&A time.
+
+## Projects
+
+See the [Hacking at OHW24 page](../projects/index.md) for more information. Feel free to post a question on the `#ohw24_project` channel, too.
+
+## Reporting a Code of Conduct violation
+
+Harassment and other [Code of Conduct violations](../../about/code-of-conduct.md) reduce the value of OceanHackWeek for everyone. If someone makes you or anyone else feel unsafe or unwelcome, please report it as soon as possible to one of the instructors. You can make a report either personally or anonymously. **Anonymous reports can be made [here](https://ohwcoc.wufoo.com/forms/z71akf608vqrgd/).**
+

--- a/ohw24/logistics/index.md
+++ b/ohw24/logistics/index.md
@@ -1,0 +1,46 @@
+# Logistics Overview
+
+Some of you will participate in person in East Boothbay and others in Sydney. ~~and others will participate virtually from time zones all over the world. Each of these gathering styles has strengths and weaknesses.~~ We are committed to providing an engaging and full experience for everyone and will strive to facilitate cross communication and collaboration across all participants.
+
+## Time
+
+OceanHackWeek 2024 will take place:
+
+- August 26-30 for ~~the virtual event and~~ the in-person event in East Boothbay, Maine,, US
+- August 8-12 for the in-person event in Western Australia (**DO YOU INTEND TO LIST THE TWO EVENTS HERE?**)
+
+In-person participants will be engaged in OceanHackWeek throughout the day. ~~The virtual event will take place in a 3-hour daily block of formal, live activities, 09:00am - 12:00pm PDT / 16:00 - 19:00 UTC.~~
+
+**Detailed schedules are available on the [Schedule page](../schedule.md).**
+
+
+## Channel of communication: Slack
+
+We will use the [OceanHackWeek Slack workspace](http://oceanhackweek.slack.com/) as the main channel of communication before, during, and after the hackweek. You should have received an invitation to join this workspace. If you haven't seen it in your inbox, check your spam folder, or email us at *info@oceanhackweek.org*.
+
+[Go directly from a channel or direct message chat into a voice or video chat](https://slack.com/help/articles/216771908-Make-calls-in-Slack), with screen-sharing capability. This will be particularly useful during hack project time.
+
+## OHW JupyterHub ("The Hub") and GitHub
+
+- OHW JupyterHub ("The Hub"): [https://oceanhackweek.2i2c.cloud](https://oceanhackweek.2i2c.cloud)
+- OHW GitHub organization: [https://github.com/oceanhackweek](https://github.com/oceanhackweek)
+
+## Tutorials broadcasting
+
+We will use Zoom to broadcast all tutorials. The Zoom link will be distributed via Slack.
+
+## Hack projects
+
+See the [Hacking at OHW24 page](../projects/index.md) for more information.
+
+## Getting Help
+
+See the [Getting Help page](getting_help.md) for guidance and links to have your questions answered or connect with organizers with concerns.
+
+```{toctree}
+:hidden:
+
+Overview <./overview>
+Getting Help <getting_help>
+```
+

--- a/ohw24/logistics/index.md
+++ b/ohw24/logistics/index.md
@@ -1,15 +1,13 @@
 # Logistics Overview
 
-Some of you will participate in person in East Boothbay and others in Sydney. ~~and others will participate virtually from time zones all over the world. Each of these gathering styles has strengths and weaknesses.~~ We are committed to providing an engaging and full experience for everyone and will strive to facilitate cross communication and collaboration across all participants.
+Some of you will participate in person in East Boothbay and others in Sydney. We are committed to providing an engaging and full experience for everyone and will strive to facilitate cross communication and collaboration across all participants.
 
 ## Time
 
-OceanHackWeek 2024 will take place:
+OceanHackWeek 2024 will take place August 26-30 for the in-person event in East Boothbay, Maine, US and in Western Australia.
 
-- August 26-30 for ~~the virtual event and~~ the in-person event in East Boothbay, Maine,, US
-- August 8-12 for the in-person event in Western Australia (**DO YOU INTEND TO LIST THE TWO EVENTS HERE?**)
 
-In-person participants will be engaged in OceanHackWeek throughout the day. ~~The virtual event will take place in a 3-hour daily block of formal, live activities, 09:00am - 12:00pm PDT / 16:00 - 19:00 UTC.~~
+In-person participants will be engaged in OceanHackWeek throughout the day.
 
 **Detailed schedules are available on the [Schedule page](../schedule.md).**
 

--- a/ohw24/projects/index.md
+++ b/ohw24/projects/index.md
@@ -1,0 +1,27 @@
+# Hacking at OHW24
+
+## How will the projects be conducted?
+
+We encourage project ideas from participants! Feel free to discuss existing or new project ideas **#ohw24_project** Slack channel prior to the event. Once ideas begin to gel and collaborative groups begin to form, the group can start getting into the weeds using a [Google Jamboard](https://jamboard.google.com/d/1lOgVwnqQLvNRPAOEVEGnWXm8FSTuPYQWbteptKrslTM/viewer?f=0). Later the group needs to create and present a visual [elevator speech](https://en.wikipedia.org/wiki/Elevator_pitch) using one [Google Slide](https://docs.google.com/presentation/d/1eQKSdFHNGMDqGJMY4d-yGnNm4UrUj5kIS2mLQGPMZC8/edit#slide=id.p), create a project Slack channel that starts with `ohw24_proj_` (say, `ohw24_proj_upwelling`), and create a Github repository (follow [these instructions](https://oceanhackweek.org/resources/prep/git.html#create-a-project-repository)). For the repository, please create a `README.md` file following [this README template](https://github.com/oceanhackweek/ohwyy_proj_template).
+
+We've scheduled part of Day 1 and the early part of Day 2 for project ideation. After that, time not allocated to shared tutorials and discussions may be devoted to working on the projects - hacking!
+
+Please look over the information below for guidance about projects, how to get started and the motivations for working on projects.
+
+## OHW24 projects list
+
+Check out the [projects that formed this year!](projects_thisyear.md)
+
+## Project overview
+
+```{include} ../../resources/projects.md
+:start-after: "# Project Overview"
+```
+
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+./projects_thisyear
+```

--- a/ohw24/projects/index.md
+++ b/ohw24/projects/index.md
@@ -2,15 +2,17 @@
 
 ## How will the projects be conducted?
 
-We encourage project ideas from participants! Feel free to discuss existing or new project ideas **#ohw24_project** Slack channel prior to the event. Once ideas begin to gel and collaborative groups begin to form, the group can start getting into the weeds using a [Google Jamboard](https://jamboard.google.com/d/1lOgVwnqQLvNRPAOEVEGnWXm8FSTuPYQWbteptKrslTM/viewer?f=0). Later the group needs to create and present a visual [elevator speech](https://en.wikipedia.org/wiki/Elevator_pitch) using one [Google Slide](https://docs.google.com/presentation/d/1eQKSdFHNGMDqGJMY4d-yGnNm4UrUj5kIS2mLQGPMZC8/edit#slide=id.p), create a project Slack channel that starts with `ohw24_proj_` (say, `ohw24_proj_upwelling`), and create a Github repository (follow [these instructions](https://oceanhackweek.org/resources/prep/git.html#create-a-project-repository)). For the repository, please create a `README.md` file following [this README template](https://github.com/oceanhackweek/ohwyy_proj_template).
+We encourage project ideas from participants! Feel free to discuss existing or new project ideas **#ohw24_project** Slack channel prior to the event. Once ideas begin to gel and collaborative groups begin to form, the group can start getting into the weeds using a [Google Jamboard](https://jamboard.google.com/d/1lOgVwnqQLvNRPAOEVEGnWXm8FSTuPYQWbteptKrslTM/viewer?f=0) or a combination of sticky notes and whiteboards. Later, each group needs to create a project Slack channel that starts with `ohw24_proj_` (say, `ohw24_proj_upwelling`), and create a Github repository (follow [these instructions](https://oceanhackweek.org/resources/prep/git.html#create-a-project-repository)). For the repository, please create a `README.md` file following [this README template](https://github.com/oceanhackweek/ohwyy_proj_template).
 
-We've scheduled part of Day 1 and the early part of Day 2 for project ideation. After that, time not allocated to shared tutorials and discussions may be devoted to working on the projects - hacking!
+<!-- and present a visual [elevator speech](https://en.wikipedia.org/wiki/Elevator_pitch) using one [Google Slide](https://docs.google.com/presentation/d/1eQKSdFHNGMDqGJMY4d-yGnNm4UrUj5kIS2mLQGPMZC8/edit#slide=id.p),  -->
+
+We've scheduled part of Day 1 for project ideation and the morning of Day 2 for setting up Slack channels and GitHub repositories. After that, time not allocated to shared tutorials and discussions may be devoted to working on the projects - hacking!
 
 Please look over the information below for guidance about projects, how to get started and the motivations for working on projects.
 
-## OHW24 projects list
+<!-- ## OHW24 projects list
 
-Check out the [projects that formed this year!](projects_thisyear.md)
+Check out the [projects that formed this year!](projects_thisyear.md) -->
 
 ## Project overview
 
@@ -23,5 +25,5 @@ Check out the [projects that formed this year!](projects_thisyear.md)
 :maxdepth: 1
 :hidden:
 
-./projects_thisyear
+<!-- ./projects_thisyear -->
 ```

--- a/ohw24/projects/projects_thisyear.md
+++ b/ohw24/projects/projects_thisyear.md
@@ -1,0 +1,13 @@
+# OHW24 Projects List
+
+Projects from OceanHackWeek 2024.
+
+The list of projects will be fleshed out here as they it comes together. Here is an example of ideal (if not always fully possible) project information, from OHW23:
+
+### 1. Marine species distribution modeling tutorial: sea turtles
+
+- Project members: Catherine Courtier, Mackenzie Fiss, Denisse Fierro Arcos, Paulo Freire, Jade Hong, Caitlin O’Brien, Mary Solokas, Laura Tsang, Eli Holmes, Tylar Murray, Ben Tupper
+- GitHub repository: [https://github.com/oceanhackweek/ohw23_proj_marinesdms](https://github.com/oceanhackweek/ohw23_proj_marinesdms)
+- Presentation recordings: [Seattle + Virtual](https://youtu.be/6QGf7lvykC0) and [Australia](https://youtu.be/j4C2Y5GurQU?list=PLVH-j9gOscWmTQNctTx07pf97BRuUxCBX&t=924)
+- Product: [Marine Species Distribution tutorial](https://oceanhackweek.org/ohw23_proj_marinesdms/)
+- [Project pitch slide](https://docs.google.com/presentation/d/1eQKSdFHNGMDqGJMY4d-yGnNm4UrUj5kIS2mLQGPMZC8/edit#slide=id.g25f8e87bf15_11_0)

--- a/ohw24/schedule.md
+++ b/ohw24/schedule.md
@@ -1,0 +1,21 @@
+# Schedule
+
+```{admonition} UPDATE THIS INFORMATION TO OHW24 CONTEXT!!
+- Will you try to include the Australian schedule here?
+- A link to convert timezones may not be useful if you're not supporting virtual participation
+- Update the link to the OHW24 US schedule Google Sheet, after "publishing" it (Alex or Emilio can help with that)
+```
+
+**OceanHackWeek 2024 will take place on:**
+
+- August 26-30 for the the in-person event in East Boothbay, Maine, US
+- ~~August 8-12 for the in-person event in Western Australia~~
+
+**All times below are shown in "EDT", Pacific Daylight savings Time (UTC-5).** You can [use this link to convert](https://www.timeanddate.com/worldclock/converter.html?iso=20230807T160000&p1=1440&p2=234&p3=196&p4=16&p5=179) to your own local times.
+
+
+## US in-person schedule
+
+<iframe width=700 height=600 src="https://docs.google.com/spreadsheets/d/e/2PACX-1vQDKxlU84Ih9aipNGxoNSDc-b1wuHV-DK2sTZT1YfuvFcaVadFqfLWqrU6AvZMu6IEwLmqKciBZrDmx/pubhtml?gid=539810478&single=true&amp;widget=true&amp;headers=false"></iframe>
+
+

--- a/ohw24/schedule.md
+++ b/ohw24/schedule.md
@@ -1,21 +1,18 @@
 # Schedule
-
+<!-- 
 ```{admonition} UPDATE THIS INFORMATION TO OHW24 CONTEXT!!
 - Will you try to include the Australian schedule here?
 - A link to convert timezones may not be useful if you're not supporting virtual participation
 - Update the link to the OHW24 US schedule Google Sheet, after "publishing" it (Alex or Emilio can help with that)
-```
+``` -->
 
 **OceanHackWeek 2024 will take place on:**
 
 - August 26-30 for the the in-person event in East Boothbay, Maine, US
-- ~~August 8-12 for the in-person event in Western Australia~~
+<!-- - ~~August 8-12 for the in-person event in Western Australia~~ -->
 
-**All times below are shown in "EDT", Pacific Daylight savings Time (UTC-5).** You can [use this link to convert](https://www.timeanddate.com/worldclock/converter.html?iso=20230807T160000&p1=1440&p2=234&p3=196&p4=16&p5=179) to your own local times.
 
 
 ## US in-person schedule
 
-<iframe width=700 height=600 src="https://docs.google.com/spreadsheets/d/e/2PACX-1vQDKxlU84Ih9aipNGxoNSDc-b1wuHV-DK2sTZT1YfuvFcaVadFqfLWqrU6AvZMu6IEwLmqKciBZrDmx/pubhtml?gid=539810478&single=true&amp;widget=true&amp;headers=false"></iframe>
-
-
+<iframe width=700 height=600 src="https://docs.google.com/spreadsheets/d/1uzwU6hCjiu49dcl8JE0iik7nZy7LuQnrloN-i3v-fLw/pubhtml?gid=539810478&amp;single=true&amp;widget=true&amp;headers=false"></iframe>

--- a/ohw24/tutorials-index/index.md
+++ b/ohw24/tutorials-index/index.md
@@ -1,0 +1,36 @@
+# Tutorials
+
+We are pleased to present a number of tutorials during the week.  These tutorials provide a look into the work that your colleagues pursue using coding tools.  The software for most tutorials can be downloaded using the tools described in our [Tutorials Getting Started page](../tutorials_getting_started.md).  Please check the [schedule](../schedule.md) for the times of these presentations.
+
+```{admonition} Technical preparations and background for OceanHackWeek!
+- Please review the ["Preparation" materials](../../resources/prep/index.md) covering basic topics like `Git`, `GitHub`, `conda` package management and the OHW `JupyterHub`
+- For tutorials on Python and R scientific tools and techniques that we will use in OceanHackWeek, see the [OHW 2022 tutorials page](../../ohw22/tutorials-index/index.md)!
+```
+
+## Main tutorials
+
+```{admonition} UPDATE THIS INFORMATION TO OHW24 CONTEXT!!
+:class: important
+- See the [ohw23 tutorials index page](../../ohw23/tutorials-index) as a template to content for this page. 
+- Make sure to update the links to tutorials in `ohw-tutorials` repo in `toctree`, and see [https://github.com/oceanhackweek/oceanhackweek.github.io/issues/263](https://github.com/oceanhackweek/oceanhackweek.github.io/issues/263) to understand the somewhat complex, git submodules set up that links to tutorials in that repo
+```
+
+## Lectures and Discussions
+
+Finally, each year we offer brief sessions on non-coding aspects of computational oceanography; this year we are pleased to offer two.
+
+- [Joseph Gum](https://github.com/asx-) - [**Reproducible Research**](https://github.com/oceanhackweek/ohw-tutorials/blob/OHW23/00-Mon/README.md)
+- [Alex Kerney](https://github.com/abkfenris) - [**Stresses in the geosciences**](https://github.com/oceanhackweek/ohw-tutorials/tree/OHW23/02-Wed/README.md)
+
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+../tutorials_getting_started
+../tutorials/01-Tue/Data_access_methods_Python.ipynb
+machine-learning.md
+../tutorials/02-Wed/ai_assisted_programming_ohw.ipynb
+../tutorials/02-Wed/xarray-in-45-min.ipynb
+../tutorials/03-Thu/OHW_omics_lesson.ipynb
+```

--- a/ohw24/tutorials-index/index.md
+++ b/ohw24/tutorials-index/index.md
@@ -9,18 +9,42 @@ We are pleased to present a number of tutorials during the week.  These tutorial
 
 ## Main tutorials
 
-```{admonition} UPDATE THIS INFORMATION TO OHW24 CONTEXT!!
+<!-- ```{admonition} UPDATE THIS INFORMATION TO OHW24 CONTEXT!!
 :class: important
 - See the [ohw23 tutorials index page](../../ohw23/tutorials-index) as a template to content for this page. 
 - Make sure to update the links to tutorials in `ohw-tutorials` repo in `toctree`, and see [https://github.com/oceanhackweek/oceanhackweek.github.io/issues/263](https://github.com/oceanhackweek/oceanhackweek.github.io/issues/263) to understand the somewhat complex, git submodules set up that links to tutorials in that repo
-```
+``` -->
+
+The following tutorials will be presented live during the **US sessions**, and will be recorded for later review.
+
+### Monday, August 26th
+[Christian Sarason](https://apl.uw.edu/people/profile.php?last_name=Sarason&first_name=Christian) Fight the dreaded 'It works for me' demon with conda package management and jupyter notebooks: This tutorial will describe some of the pros, cons and pitfalls of package management and take quick tour of Pixi and JupyterLab using an example project.
+
+### Tuesday, August 27th
+
+[Callum Rollo](https://callumrollo.github.io/) - Data Access in Python: In this tutorial, participants will use Python to find and access ocean data via a range of protocols including ERDDAP, OPeNDAP and WMS. 
+
+[Rich Signell](https://opensciencecomputing.com/) - Xarray Tutorial 
+
+[Ciara Dorsay](https://www.linkedin.com/in/ciara-dorsay/) - Assessing weather model skill during extreme events: NOAA GFS vs. Sofar Spotter buoy observations of Hurricane Henri: In this tutorial, participants will learn how to query data of different formats (point-wise buoy, gridded weather model) from Amazon's S3 cloud object storage system, collocate the two, and calculate and visualize the differences between them during a notable weather event using Python.
+
+### Wednesday, August 28th
+
+[Myranda Shirk](https://www.vanderbilt.edu/datascience/person/myranda-uselton-shirk/?type=lab) - AI-Assisted Programming: With the recent success of large language models (LLMs) such as ChatGPT, mastery of a programming language is no longer required to write successful code. In this tutorial, we will explore the new workflow of AI-assisted programming and how it can streamline your hackathon project, no matter your coding experience.
+
+[Jiarui Yu](https://www.linkedin.com/in/jiarui-yu-0b0ab522b/) - Introduction to Transformers: This tutorial includes Transformer’s encoder structure in detail, presenting attention mechanism and transforming the encoder to VIT in order to process 2-d image classification. 
+
+### Thursday, August 29th
+[Camille Ross](https://www.neaq.org/person/camille-ross/) - R Application 
+
 
 ## Lectures and Discussions
 
-Finally, each year we offer brief sessions on non-coding aspects of computational oceanography; this year we are pleased to offer two.
+Finally, each year we offer brief sessions on non-coding aspects of computational oceanography; this year we are pleased to offer the following.
 
-- [Joseph Gum](https://github.com/asx-) - [**Reproducible Research**](https://github.com/oceanhackweek/ohw-tutorials/blob/OHW23/00-Mon/README.md)
-- [Alex Kerney](https://github.com/abkfenris) - [**Stresses in the geosciences**](https://github.com/oceanhackweek/ohw-tutorials/tree/OHW23/02-Wed/README.md)
+- [Eli Holmes](https://www.fisheries.noaa.gov/contact/elizabeth-holmes-phd) - **Reproducible Collaboration**.
+- [Myranda Shirk](https://www.vanderbilt.edu/datascience/person/myranda-uselton-shirk/?type=lab)  - **AI use-case discussion** following a tutorial on AI-Assisted Programming.
+- [Alex Kerney](https://github.com/abkfenris) - [**Stresses in the geosciences**](https://github.com/oceanhackweek/ohw-tutorials/tree/OHW23/02-Wed/README.md), an open discussion about mental health in the geosciences.
 
 
 ```{toctree}

--- a/ohw24/tutorials_getting_started.md
+++ b/ohw24/tutorials_getting_started.md
@@ -1,0 +1,37 @@
+# Getting started on tutorials
+
+## Introduction
+
+Tutorials will be run live on the [OceanHackWeek JupyterHub ("The Hub"), https://oceanhackweek.2i2c.cloud](https://oceanhackweek.2i2c.cloud) in your browser either as Jupyter notebooks or as scripts and notebooks in RStudio. The instructor and all participants can be running their own copies of the tutorial in their Hub account, with files cloned from the OHW source in GitHub.
+
+Below are instructions for getting the tutorials started on the the Hub in your browser, and updating the tutorials files with the latest version from the GitHub tutorials repository, [https://github.com/oceanhackweek/ohw-tutorials](https://github.com/oceanhackweek/ohw-tutorials).
+
+The schedule of tutorials is available [here](../../ohw24/schedule.md), and links to tutorial materials and some background resources will be available there as well.
+
+## How do I get the tutorial repository into the Hub?
+
+For the tutorials, we recommend the use of [nbgitpuller](https://jupyterhub.github.io/nbgitpuller/) to clone and pull the tutorials repository, or update the clone you already have. Use the magical nbgitpuller link below to accomplish this clone or update.
+
+```{admonition} Pull tutorial repo via the magic of nbgitpuller
+
+The nbgitpuller link is magical, but it can't detect which profile you are currently running. Either should update the (same) tutorial repo, but it may error if you use the Python link if you are actively using the R profile, or the other way around.
+
+::::{tab-set}
+
+:::{tab-item} Python
+
+[Pull tutorial repo for the Python profile](https://oceanhackweek.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=lab%2Ftree%2Fohw-tutorials%2F&branch=OHW24)
+
+:::
+
+:::{tab-item} R
+
+[Pull tutorial repo for the R profile](https://oceanhackweek.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=rstudio%2F&branch=OHW24)
+
+:::
+
+::::
+
+```
+
+See this [extended discussion](../resources/prep/jupyterhub.md#how-do-i-get-the-tutorial-repository) for more details about `nbgitpuller` and the alternative approach relying on `git` commands and `GitHub` workflows.

--- a/resources/index.md
+++ b/resources/index.md
@@ -4,7 +4,7 @@
 **This page should be rewritten entirely!**
 ```-->
 
-To make sure that OHW23 will be a welcoming environment for everyone, please read our [Code of Conduct](/about/code-of-conduct.md) carefully as part of your preparation. We expect all participants to adhere to the Code of Conduct in all interactions throughout the hackweek.
+To make sure that OHW24 will be a welcoming environment for everyone, please read our [Code of Conduct](/about/code-of-conduct.md) carefully as part of your preparation. We expect all participants to adhere to the Code of Conduct in all interactions throughout the hackweek.
 
 ## Preparation
 


### PR DESCRIPTION
Bootstrap all the new pages for OHW24 based on OHW23 pages.

I made some simple content updates (eg, replace 23 with 24) and cleanups, added some strikethrough formatting for text that probably should be deleted, and added admonitions to highlight other changes likely needed.

So, this isn't ready for primetime, but it should be ready for you (actual OHW24 people) to make basic content updates and cleanups before merging.

Notes:
- This PR includes the same update found in @abkfenris 's PR #329. You can close that PR, or deal with the conflict later
- The schedule page links to the OHW23 Google Sheet. You'll need to update it. @abkfenris knows how to "publish" a Google Sheet and get its link, but I can also help if needed
- I don't know if you plan to fully list out information about the Australian event here, so watch out for that in the content
- Ditto for whatever virtual participation or live viewing of tutorials you'll be supporting
- The ohw website's front page still has an admonition saying that ohw24 applications are open. You should update that :wink: