### PR TITLE
Updates the micromamba action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/check_sphinx_build.yml
+++ b/.github/workflows/check_sphinx_build.yml
@@ -16,7 +16,9 @@ jobs:
           submodules: true
 
       - name: Install Conda environment from environment.yml
-        uses: mamba-org/provision-with-micromamba@v11
+        uses: mamba-org/setup-micromamba@v2.0.0
+        environment-file: environment.yml
+        cache-environment: true
 
       - name: Build documentation
         shell: bash -l {0}
@@ -29,7 +31,7 @@ jobs:
 
       # https://github.com/actions/upload-artifact
       - name: Upload Website artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: Website
           path: site.tar.gz

--- a/.github/workflows/check_sphinx_build.yml
+++ b/.github/workflows/check_sphinx_build.yml
@@ -17,8 +17,9 @@ jobs:
 
       - name: Install Conda environment from environment.yml
         uses: mamba-org/setup-micromamba@v2.0.0
-        environment-file: environment.yml
-        cache-environment: true
+        with:
+          environment-file: environment.yml
+          cache-environment: true
 
       - name: Build documentation
         shell: bash -l {0}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,7 +12,10 @@ jobs:
           submodules: true
 
       - name: Install Conda environment from environment.yml
-        uses: mamba-org/provision-with-micromamba@v11
+        uses: mamba-org/setup-micromamba@v2.0.0
+        environment-file: environment.yml
+        cache-environment: true
+    
 
       - name: Build documentation
         shell: bash -l {0}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,8 +13,9 @@ jobs:
 
       - name: Install Conda environment from environment.yml
         uses: mamba-org/setup-micromamba@v2.0.0
-        environment-file: environment.yml
-        cache-environment: true
+        with:
+          environment-file: environment.yml
+          cache-environment: true
     
 
       - name: Build documentation


### PR DESCRIPTION
The micromamba action that we were using was deprecated and didn't handle the Micromamba v2 upgrade well. This should move things to the supported action.

I've also added Dependabot for Github Actions, so that will hopefully help at least that part of the workflows stay up to date.

Hopefully addresses failure in #334 