### PR TITLE
Disable linkcheck for now

### DIFF
--- a/.github/workflows/check_sphinx_build.yml
+++ b/.github/workflows/check_sphinx_build.yml
@@ -27,7 +27,12 @@ jobs:
       - name: Build documentation
         shell: bash -l {0}
         run: |
-          make html linkcheck
+          make html
+
+      # - name: Check links
+      #   shell: bash -l {0}
+      #   run: |
+      #     make linkcheck
 
       # workaround https://github.com/actions/upload-artifact/issues/38
       - name: tarball


### PR DESCRIPTION
Disabling Sphinx linkchecking for now to unblock other PRs. I'll try to follow up with it re-enabled and some of the errors cleaned up.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #361 
- <kbd>&nbsp;1&nbsp;</kbd> #360 👈 
<!-- GitButler Footer Boundary Bottom -->

