### PR TITLE
Update links to Openscapes

### DIFF
--- a/ohw25/logistics/index.md
+++ b/ohw25/logistics/index.md
@@ -17,7 +17,7 @@ We will use the [OceanHackWeek Slack workspace](http://oceanhackweek.slack.com/)
 
 ## OHW JupyterHub ("The Hub") and GitHub
 
-- OHW JupyterHub ("The Hub"): [https://oceanhackweek.2i2c.cloud](https://oceanhackweek.2i2c.cloud)
+- OHW JupyterHub ("The Hub"): [https://workshop.nmfs-openscapes.2i2c.cloud](https://workshop.nmfs-openscapes.2i2c.cloud)
 - OHW GitHub organization: [https://github.com/oceanhackweek](https://github.com/oceanhackweek)
 
 ## Tutorials broadcasting

--- a/ohw25/tutorials_getting_started.md
+++ b/ohw25/tutorials_getting_started.md
@@ -2,11 +2,11 @@
 
 ## Introduction
 
-Tutorials will be run live on the [OceanHackWeek JupyterHub ("The Hub"), https://oceanhackweek.2i2c.cloud](https://oceanhackweek.2i2c.cloud) in your browser either as Jupyter notebooks or as scripts and notebooks in RStudio. The instructor and all participants can be running their own copies of the tutorial in their Hub account, with files cloned from the OHW source in GitHub.
+Tutorials will be run live on the [Openscapes JupyterHub ("The Hub"), https://workshop.nmfs-openscapes.2i2c.cloud](https://workshop.nmfs-openscapes.2i2c.cloud) in your browser either as Jupyter notebooks or as scripts and notebooks in RStudio. The instructor and all participants can be running their own copies of the tutorial in their Hub account, with files cloned from the OHW source in GitHub.
 
 Below are instructions for getting the tutorials started on the the Hub in your browser, and updating the tutorials files with the latest version from the GitHub tutorials repository, [https://github.com/oceanhackweek/ohw-tutorials](https://github.com/oceanhackweek/ohw-tutorials).
 
-The schedule of tutorials is available [here](../../ohw24/schedule.md), and links to tutorial materials and some background resources will be available there as well.
+The schedule of tutorials is available [here](../../ohw25/schedule.md), and links to tutorial materials and some background resources will be available there as well.
 
 ## How do I get the tutorial repository into the Hub?
 
@@ -20,13 +20,13 @@ The nbgitpuller link is magical, but it can't detect which profile you are curre
 
 :::{tab-item} Python
 
-[Pull tutorial repo for the Python profile](https://oceanhackweek.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=lab%2Ftree%2Fohw-tutorials%2F&branch=OHW24)
+[Pull tutorial repo for the Python profile](https://workshop.nmfs-openscapes.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=lab%2Ftree%2Fohw-tutorials%2F&branch=OHW25)
 
 :::
 
 :::{tab-item} R
 
-[Pull tutorial repo for the R profile](https://oceanhackweek.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=rstudio%2F&branch=OHW24)
+[Pull tutorial repo for the R profile](https://workshop.nmfs-openscapes.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=rstudio%2F&branch=OHW24)
 
 :::
 

--- a/resources/prep/jupyterhub.md
+++ b/resources/prep/jupyterhub.md
@@ -20,7 +20,7 @@ We encourage you to use our shared JupyterHub resources for running all the tuto
 
 ## How do I access the shared cloud environment?
 
-Access to our shared cloud environment is easy. Click on [https://oceanhackweek.2i2c.cloud](https://oceanhackweek.2i2c.cloud)
+Access to our shared cloud environment by clicking on [https://workshop.nmfs-openscapes.2i2c.cloud](https://workshop.nmfs-openscapes.2i2c.cloud)
 
 ![hub-opening](../img/ohw21-jupyterhub-opening.png)
 
@@ -54,13 +54,13 @@ The nbgitpuller link is magical, but it can't detect which profile you are curre
 
 :::{tab-item} Python
 
-[Pull tutorial repo for the Python profile](https://oceanhackweek.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=lab%2Ftree%2Fohw-tutorials%2F&branch=OHW24)
+[Pull tutorial repo for the Python profile](https://workshop.nmfs-openscapes.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=lab%2Ftree%2Fohw-tutorials%2F&branch=OHW25)
 
 :::
 
 :::{tab-item} R
 
-[Pull tutorial repo for the R profile](https://oceanhackweek.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=rstudio%2F&branch=OHW24)
+[Pull tutorial repo for the R profile](https://workshop.nmfs-openscapes.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=rstudio%2F&branch=OHW25)
 
 :::
 
@@ -121,13 +121,13 @@ If you are **using JupyterLab**, you access the control via `File > Hub Control 
 
 ![hub shut down step 1](../img/ohw21-shutdownhub-step1.png)
 
-Then you can shut down your server from your hub control panel (which you can also access directly from [https://oceanhackweek.2i2c.cloud/hub/home](https://oceanhackweek.2i2c.cloud/hub/home)):
+Then you can shut down your server from your hub control panel (which you can also access directly from [https://workshop.nmfs-openscapes.2i2c.cloud/hub/home](https://workshop.nmfs-openscapes.2i2c.cloud/hub/home)):
 
 ![hub shut down step 2](../img/ohw21-shutdownhub-step2.png)
 
 Note that the menu item `File > Log Out` doesn't actually shut down the server, so please follow these steps instead.
 
-If you are **using RStudio**, the `Log out` and `Quit session` entries under the `File` menu won't do much! Shut down your server from your hub control panel [https://oceanhackweek.2i2c.cloud/hub/home](https://oceanhackweek.2i2c.cloud/hub/home)), as described above.
+If you are **using RStudio**, the `Log out` and `Quit session` entries under the `File` menu won't do much! Shut down your server from your hub control panel [https://workshop.nmfs-openscapes.2i2c.cloud/hub/home](https://workshop.nmfs-openscapes.2i2c.cloud/hub/home)), as described above.
 
 ```{admonition} Note
 :class: important

--- a/resources/tutorials/getting_started.md
+++ b/resources/tutorials/getting_started.md
@@ -2,11 +2,11 @@
 
 ## Introduction
 
-Tutorials will be run live on the [OceanHackWeek JupyterHub ("The Hub"), https://oceanhackweek.2i2c.cloud](https://oceanhackweek.2i2c.cloud) in your browser either as Jupyter notebooks or as scripts and notebooks in RStudio. The instructor and all participants can be running their own copies of the tutorial in their Hub account, with files cloned from the OHW source in GitHub.
+Tutorials will be run live on the [Openscapes JupyterHub ("The Hub"), https://workshop.nmfs-openscapes.2i2c.cloud](https://workshop.nmfs-openscapes.2i2c.cloud) in your browser either as Jupyter notebooks or as scripts and notebooks in RStudio. The instructor and all participants can be running their own copies of the tutorial in their Hub account, with files cloned from the OHW source in GitHub.
 
 Below are instructions for getting the tutorials started on the the Hub in your browser, and updating the tutorials files with the latest version from the GitHub tutorials repository, [https://github.com/oceanhackweek/ohw-tutorials](https://github.com/oceanhackweek/ohw-tutorials).
 
-The schedule of tutorials is available [here](../../ohw22/schedule.md), and links to tutorial materials and some background resources will be available there as well.
+The schedule of tutorials is available [here](../../ohw25/schedule.md), and links to tutorial materials and some background resources will be available there as well.
 
 ## How do I get the tutorial repository into the Hub?
 
@@ -20,13 +20,13 @@ The nbgitpuller link is magical, but it can't detect which profile you are curre
 
 :::{tab-item} Python
 
-[Pull tutorial repo for the Python profile](https://oceanhackweek.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=lab%2Ftree%2Fohw-tutorials%2F&branch=OHW22)
+[Pull tutorial repo for the Python profile](https://workshop.nmfs-openscapes.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=lab%2Ftree%2Fohw-tutorials%2F&branch=OHW25)
 
 :::
 
 :::{tab-item} R
 
-[Pull tutorial repo for the R profile](https://oceanhackweek.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=rstudio%2F&branch=OHW22)
+[Pull tutorial repo for the R profile](https://workshop.nmfs-openscapes.2i2c.cloud/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Foceanhackweek%2Fohw-tutorials&urlpath=rstudio%2F&branch=OHW25)
 
 :::
 


### PR DESCRIPTION
Updates the general and nb-git-puller links to point to the Openscapes hub, and the correct branch of the tutorial repo.