### PR TITLE
Add Fellows teams page

### DIFF
--- a/about/fellows-team.md
+++ b/about/fellows-team.md
@@ -3,7 +3,9 @@ layout: page
 description: Team of OceanHackWeek Fellows
 ---
 
-# 2025 Fellows
+# OceanHackWeek Fellows
+
+## 2025
 
 ```{ohw-team}
 :roles: "OHW25 Fellow"

--- a/about/fellows-team.md
+++ b/about/fellows-team.md
@@ -1,0 +1,12 @@
+---
+layout: page
+description: Team of OceanHackWeek Fellows
+---
+
+# 2025 Fellows
+
+```{ohw-team}
+:roles: "OHW25 Fellow"
+:badges:
+:hide_role_badges: "OHW18 *,OHW19 *,OHW20 *,OHW21 *,OHW22 *,OHW23 *,OHW24 *,OHW25 Organizer*,OHW25 Project*,OHW25 Mentor*,OHW25 Tutorial*,*Participant*,Steering *,Tutorials,Infrastructure,Applicant Selection,Projects,Financial Planning,Website"
+```

--- a/about/fellows.md
+++ b/about/fellows.md
@@ -34,3 +34,10 @@ Applications are closed. Accepted applicants will be notified no later than July
 
 For general questions, please email info@oceanhackweek.org
 
+```{toctree}
+:maxdepth: 3
+:caption: OHW Fellows
+:hidden:
+
+Past Fellows <fellows-team>
+```


### PR DESCRIPTION
Fellows were already listed and tagged in teams.yaml, so I'm creating a dedicated Fellows "team" page to surface OHW25 Fellows more prominently