### PR TITLE
Remove Fellows from main menu

### DIFF
--- a/about/pasthackweeks.md
+++ b/about/pasthackweeks.md
@@ -86,6 +86,7 @@ OceanHackWeek started out as an in-person event in Seattle with limited virtual 
 :maxdepth: 1
 :hidden:
 
+../ohw25/index.md
 ../ohw24/index.md
 ../ohw23/index.md
 ../ohw22/index.md

--- a/index.md
+++ b/index.md
@@ -241,7 +241,6 @@ Thanks to our sponsors that have made OceanHackWeek possible over the last sever
 
 about/index.md
 OHW 2026 <ohw26/index.md>
-OHW Fellows <about/fellows.md>
 resources/index.md
 about/pasthackweeks.md
 ```

--- a/ohw25/index.md
+++ b/ohw25/index.md
@@ -151,4 +151,5 @@ Logistics <logistics/index>
 tutorials-index/index
 Projects <projects/index>
 Information for Applicants <applicants>
+OHW Fellows <../about/fellows.md>
 ```


### PR DESCRIPTION
Remove the Fellows pages from the main menu since we don’t have the funding to make that happen this year, and move those links under OHW25 for now.

Adds OHW25 to the past hackweeks menu structure.